### PR TITLE
[Bug] Remove cookie check when validating offline sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Allow passing in options for the Redis client used by the session storage strategy [#430](https://github.com/Shopify/shopify-api-node/pull/430)
 - ⚠️ [Breaking] If a response from a GraphQL query contains an `errors` attribute, `GraphqlClient` will now throw a `GraphqlQueryError`. The caller can check the `error.response` attribute to see what was returned from the GraphQL API. [#431](https://github.com/Shopify/shopify-api-node/pull/431)
+- Add optional `isOnline` parameter to `Auth` method `validateAuthCallback` [#272](https://github.com/Shopify/shopify-api-node/pull/272)
 
 ## [4.2.0] - 2022-07-20
 

--- a/src/auth/oauth/__tests__/oauth.test.ts
+++ b/src/auth/oauth/__tests__/oauth.test.ts
@@ -298,7 +298,7 @@ describe('validateAuthCallback', () => {
   });
 
   test('requests access token for valid callbacks with offline access and updates session', async () => {
-    await ShopifyOAuth.beginAuth(req, res, shop, '/some-callback');
+    await ShopifyOAuth.beginAuth(req, res, shop, '/some-callback', false);
     let session = await Context.SESSION_STORAGE.loadSession(
       ShopifyOAuth.getOfflineSessionId(shop),
     );
@@ -320,10 +320,10 @@ describe('validateAuthCallback', () => {
 
     fetchMock.mockResponse(JSON.stringify(successResponse));
     Cookies.prototype.set.mockImplementation(() => {
-      throw new Error("offline sessions should not depend on cookies");
+      throw new Error('offline sessions should not depend on cookies');
     });
     Cookies.prototype.get.mockImplementation(() => {
-      throw new Error("offline sessions should not depend on cookies");
+      throw new Error('offline sessions should not depend on cookies');
     });
     await ShopifyOAuth.validateAuthCallback(req, res, testCallbackQuery, false);
     session = await Context.SESSION_STORAGE.loadSession(

--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -120,9 +120,7 @@ const ShopifyOAuth = {
         );
       }
 
-      currentSession = await Context.SESSION_STORAGE.loadSession(
-        sessionCookie,
-      );
+      currentSession = await Context.SESSION_STORAGE.loadSession(sessionCookie);
     } else {
       currentSession = await Context.SESSION_STORAGE.loadSession(
         ShopifyOAuth.getOfflineSessionId(query.shop),

--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -156,7 +156,7 @@ const ShopifyOAuth = {
     const client = new HttpClient(currentSession.shop);
     const postResponse = await client.post(postParams);
 
-    if (isOnline) {
+    if (currentSession.isOnline) {
       const responseBody = postResponse.body as OnlineAccessResponse;
       const {access_token, scope, ...rest} = responseBody; // eslint-disable-line @typescript-eslint/naming-convention
       const sessionExpiration = new Date(

--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -105,7 +105,7 @@ const ShopifyOAuth = {
     request: http.IncomingMessage,
     response: http.ServerResponse,
     query: AuthQuery,
-    isOnline: boolean = true,
+    isOnline = true,
   ): Promise<SessionInterface> {
     Context.throwIfUninitialized();
     Context.throwIfPrivateApp('Cannot perform OAuth for private apps');

--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -156,7 +156,7 @@ const ShopifyOAuth = {
     const client = new HttpClient(currentSession.shop);
     const postResponse = await client.post(postParams);
 
-    if (currentSession.isOnline) {
+    if (isOnline) {
       const responseBody = postResponse.body as OnlineAccessResponse;
       const {access_token, scope, ...rest} = responseBody; // eslint-disable-line @typescript-eslint/naming-convention
       const sessionExpiration = new Date(
@@ -187,14 +187,6 @@ const ShopifyOAuth = {
         }
         currentSession = jwtSession;
       }
-    } else {
-      // Offline sessions (embedded / non-embedded) will use the same id so they don't need to be updated
-      const responseBody = postResponse.body as AccessTokenResponse;
-      currentSession.accessToken = responseBody.access_token;
-      currentSession.scope = responseBody.scope;
-    }
-
-    if (isOnline) {
       const cookies = new Cookies(request, response, {
         keys: [Context.API_SECRET_KEY],
         secure: true,
@@ -206,6 +198,11 @@ const ShopifyOAuth = {
         sameSite: 'lax',
         secure: true,
       });
+    } else {
+      // Offline sessions (embedded / non-embedded) will use the same id so they don't need to be updated
+      const responseBody = postResponse.body as AccessTokenResponse;
+      currentSession.accessToken = responseBody.access_token;
+      currentSession.scope = responseBody.scope;
     }
 
     const sessionStored = await Context.SESSION_STORAGE.storeSession(

--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -124,11 +124,8 @@ const ShopifyOAuth = {
         sessionCookie,
       );
     } else {
-      currentSession = new Session(
-        this.getOfflineSessionId(query.shop),
-        query.shop,
-        query.state,
-        false,
+      currentSession = await Context.SESSION_STORAGE.loadSession(
+        ShopifyOAuth.getOfflineSessionId(query.shop),
       );
     }
 

--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -99,6 +99,7 @@ const ShopifyOAuth = {
    * @param response Current HTTP Response
    * @param query Current HTTP Request Query, containing the information to be validated.
    *              Depending on framework, this may need to be cast as "unknown" before being passed.
+   * @param isOnline Whether the session is online or offline
    * @returns SessionInterface
    */
   async validateAuthCallback(


### PR DESCRIPTION
### WHY are these changes introduced?

Offline sessions don't need or require cookies in order to be used, yet `validateAuthCallback` always checks for cookies.

This makes it difficult to use offline sessions in a scenario where cookies cannot be used, despite it being possible.

### WHAT is this pull request doing?

Add a `isOnline` parameter to `validateAuthCallback`. By default it is set to true so the change is non-breaking.

If it is set to false, all steps where cookies are checked are bypassed. Also, the session is loaded from the default offline session instead of from the cookie.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
