### PR TITLE
Fix`PostgreSQLSessionStorage@hasSessionTable` always return false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Add support for July 2022 API version [#409](https://github.com/Shopify/shopify-node-api/pull/409)
 
+### Fixes
+
+- PostgreSQL session storage don't create table if table exists
+
 ## [3.1.3] - 2022-06-08
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixes
 
-- PostgreSQL session storage don't create table if table exists
+- Fix a bug where the PostgreSQL session storage always attempted to create the sessions table [#413](https://github.com/Shopify/shopify-api-node/pull/413)
 
 ## [3.1.3] - 2022-06-08
 

--- a/src/auth/session/storage/postgresql.ts
+++ b/src/auth/session/storage/postgresql.ts
@@ -106,7 +106,7 @@ export class PostgreSQLSessionStorage implements SessionStorage {
     const query = `
       SELECT * FROM pg_catalog.pg_tables WHERE tablename = $1
     `;
-    const [rows] = await this.query(query, [this.options.sessionTableName]);
+    const rows = await this.query(query, [this.options.sessionTableName]);
     return Array.isArray(rows) && rows.length === 1;
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #412

`PostgreSQLSessionStorage@hasSessionTable` function calls `PostgreSQLSessionStorage@query` and check the length of return rows. But the `query` function return `rows` directly instead of `[rows]`, so after the array restructuring, `rows` will always be `undefined`, which cause function `hasSessionTable` returns false even the table exists.

### WHAT is this pull request doing? 

Remove array destructuring.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
