### PR TITLE
Add a new utility for constructing the host URL for the app.

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -75,3 +75,5 @@ export class SessionStorageError extends ShopifyError {}
 
 export class MissingRequiredArgument extends ShopifyError {}
 export class UnsupportedClientType extends ShopifyError {}
+
+export class InvalidRequestError extends ShopifyError {}

--- a/src/utils/__tests__/get-host-app-url.test.ts
+++ b/src/utils/__tests__/get-host-app-url.test.ts
@@ -1,0 +1,47 @@
+import http from 'http';
+
+import getHostAppUrl from '../get-host-app-url';
+import * as ShopifyErrors from '../../error';
+import {Context} from '../../context';
+
+describe('getHostAppUrl', () => {
+  beforeEach(() => {
+    Context.API_KEY = 'my-api-key';
+  });
+
+  test('thows an error when no request is passed', () => {
+    // @ts-expect-error: For JS users test it throws when no request is passed
+    expect(() => getHostAppUrl()).toThrow(
+      ShopifyErrors.MissingRequiredArgument,
+    );
+  });
+
+  test('thows an error when the request has no URL', () => {
+    const req = {
+      url: undefined,
+    } as http.IncomingMessage;
+
+    expect(() => getHostAppUrl(req)).toThrow(ShopifyErrors.InvalidRequestError);
+  });
+
+  test('thows an error when the request has no host query param', () => {
+    const req = {
+      url: 'www.example.com',
+    } as http.IncomingMessage;
+
+    expect(() => getHostAppUrl(req)).toThrow(ShopifyErrors.InvalidRequestError);
+  });
+
+  test('returns the host app url', () => {
+    const host = 'my-store.shopify.com';
+    const base64Host = Buffer.from(host, 'utf-8').toString('base64');
+
+    const req = {
+      url: `www.example.com?host=${base64Host}`,
+    } as http.IncomingMessage;
+
+    expect(getHostAppUrl(req)).toBe(
+      'https://my-store.shopify.com/apps/my-api-key',
+    );
+  });
+});

--- a/src/utils/get-host-app-url.ts
+++ b/src/utils/get-host-app-url.ts
@@ -1,0 +1,36 @@
+import http from 'http';
+import url from 'url';
+
+import * as ShopifyErrors from '../error';
+import {Context} from '../context';
+
+/**
+ * Helper method to get the host URL for the app.
+ *
+ * @param request Current HTTP request
+ */
+export default function getHostAppUrl(request: http.IncomingMessage): string {
+  if (!request) {
+    throw new ShopifyErrors.MissingRequiredArgument(
+      'getHostAppUrl requires a request object argument',
+    );
+  }
+
+  if (!request.url) {
+    throw new ShopifyErrors.InvalidRequestError(
+      'Request does not contain a URL',
+    );
+  }
+
+  const query = url.parse(request.url, true).query;
+
+  if (typeof query.host !== 'string') {
+    throw new ShopifyErrors.InvalidRequestError(
+      'Request does not contain a host query parameter',
+    );
+  }
+
+  const host = Buffer.from(query.host, 'base64').toString();
+
+  return `https://${host}/apps/${Context.API_KEY}`;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,6 +11,7 @@ import validateHmac from './hmac-validator';
 import validateShop from './shop-validator';
 import versionCompatible from './version-compatible';
 import withSession from './with-session';
+import getHostAppUrl from './get-host-app-url';
 
 const ShopifyUtils = {
   decodeSessionToken,
@@ -26,6 +27,7 @@ const ShopifyUtils = {
   validateShop,
   versionCompatible,
   withSession,
+  getHostAppUrl,
 };
 
 export default ShopifyUtils;


### PR DESCRIPTION
### WHY are these changes introduced?
Soon we will be recommending that apps favor server redirects within the OAuth process, rather than client side redirects using AppBridge.  To make this a little easier, we want to control that code that constructs the URL for the app.  That way it's easier for developers, and if that URL changes we can update the logic with a version bump.

### WHAT is this pull request doing?
Add a new utility called `getHostAppUrl`.  This utility constructs the host URL for an app.  

This utility will be used to get the URL to redirect to when the store does not have a token for the app.

*  [Example here](https://github.com/Shopify/shopify-app-template-node/compare/cli_three...load-inside-admin?expand=1#diff-1107ca59bb2d9a8cd268c58eb15e6d426d68d37371f73abbb8cc47a6fd75298aR172-R177)
* [Another example here](https://github.com/Shopify/shopify-app-template-node/compare/cli_three...load-inside-admin?expand=1#diff-339f370288e8edd7c41685f6e82fca547f5ff3931df26e042a893d8b21f9ea29R45-R50)

## Type of change
- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
