### PR TITLE
Add note regarding express.json middleware

### DIFF
--- a/docs/usage/webhooks.md
+++ b/docs/usage/webhooks.md
@@ -200,10 +200,10 @@ app.post('/webhooks', async (req, res) => {
 
 </details>
 
-### Note regarding Express
+### Note regarding use of body parsers
 
-If you use Express and wish to use the `express.json()` middleware in your app **and** if you use this library's `process` method to handle webhooks API calls from Shopify (which we recommend), the webhook processing must occur ***before*** calling `app.use(express.json())`.
+Please note that the use of body parsing middleware must occur **after** webhook processing.  `Shopify.Webhooks.Registry.process()` reads in the request body directly, therefore, if a body parsing middleware is used beforehand, `process` thinks the request body is empty and will return a `bad request` message back to Shopify for the webhook and raise an error.
 
-`Shopify.Webhooks.Registry.process()` reads in the request body directly. If `express.json()` is used beforehand, `process` thinks the request body is empty and will return a `bad request` message back to Shopify for the webhook and raise an error.
+To use Express as an example, if you wish to use the `express.json()` middleware in your app **and** if you use this library's `process` method to handle webhooks API calls from Shopify (which we recommend), the webhook processing must occur ***before*** calling `app.use(express.json())`.
 
 [Back to guide index](../README.md)

--- a/docs/usage/webhooks.md
+++ b/docs/usage/webhooks.md
@@ -175,7 +175,7 @@ The `process` method will handle extracting the necessary information from your 
     try {
       await Shopify.Webhooks.Registry.process(request, response);
     } catch (error) {
-      console.log(error);
+      console.log(error.message);
     }
   }
 }  // end of onRequest()
@@ -193,11 +193,17 @@ app.post('/webhooks', async (req, res) => {
   try {
     await Shopify.Webhooks.Registry.process(req, res);
   } catch (error) {
-    console.log(error);
+    console.log(error.message);
   }
 });
 ```
 
 </details>
+
+### Note regarding Express
+
+If you use Express and wish to use the `express.json()` middleware in your app **and** if you use this library's `process` method to handle webhooks API calls from Shopify (which we recommend), the webhook processing must occur ***before*** calling `app.use(express.json())`.
+
+`Shopify.Webhooks.Registry.process()` reads in the request body directly. If `express.json()` is used beforehand, `process` thinks the request body is empty and will return a `bad request` message back to Shopify for the webhook and raise an error.
 
 [Back to guide index](../README.md)


### PR DESCRIPTION
### WHY are these changes introduced?

Using `express.json()` middleware to parse the body of a webhook request before calling `Shopify.Webhooks.Registry.process()` will cause the `process()` method to return a failure.

### WHAT is this pull request doing?

Add a note to the webhook document about ☝🏻 

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above - not applicable
- [ ] I have added/updated tests for this change - not applicable
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs) - not applicable
