### PR TITLE
Return 401 on webhook validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- Return a 401 instead of 403 when webhooks fail validation [#425](https://github.com/Shopify/shopify-api-node/pull/425)
+
 ## [4.1.0] - 2022-07-14
 
 - Add new method to construct the host app URL [#419](https://github.com/Shopify/shopify-api-node/pull/419)

--- a/src/webhooks/__tests__/registry.test.ts
+++ b/src/webhooks/__tests__/registry.test.ts
@@ -387,7 +387,7 @@ describe('ShopifyWebhooks.Registry.process', () => {
       .expect(StatusCode.Ok);
   });
 
-  it('handles the request and returns Forbidden when topic is not registered', async () => {
+  it('handles the request and returns Not Found when topic is not registered', async () => {
     ShopifyWebhooks.Registry.addHandler('NONSENSE_TOPIC', {
       path: '/webhooks',
       webhookHandler: genericWebhookHandler,
@@ -409,10 +409,10 @@ describe('ShopifyWebhooks.Registry.process', () => {
       .post('/webhooks')
       .set(headers({hmac: hmac(Context.API_SECRET_KEY, rawBody)}))
       .send(rawBody)
-      .expect(StatusCode.Forbidden);
+      .expect(StatusCode.NotFound);
   });
 
-  it('handles the request and returns Forbidden when hmac does not match', async () => {
+  it('handles the request and returns Unauthorized when hmac does not match', async () => {
     ShopifyWebhooks.Registry.addHandler('PRODUCTS', {
       path: '/webhooks',
       webhookHandler: genericWebhookHandler,
@@ -434,7 +434,7 @@ describe('ShopifyWebhooks.Registry.process', () => {
       .post('/webhooks')
       .set(headers({hmac: hmac('incorrect secret', rawBody)}))
       .send(rawBody)
-      .expect(StatusCode.Forbidden);
+      .expect(StatusCode.Unauthorized);
   });
 
   it('fails if the given body is empty', async () => {

--- a/src/webhooks/registry.ts
+++ b/src/webhooks/registry.ts
@@ -422,13 +422,13 @@ const WebhooksRegistry: RegistryInterface = {
               responseError = error;
             }
           } else {
-            statusCode = StatusCode.Forbidden;
+            statusCode = StatusCode.NotFound;
             responseError = new ShopifyErrors.InvalidWebhookError(
               `No webhook is registered for topic ${topic}`,
             );
           }
         } else {
-          statusCode = StatusCode.Forbidden;
+          statusCode = StatusCode.Unauthorized;
           responseError = new ShopifyErrors.InvalidWebhookError(
             `Could not validate request for topic ${topic}`,
           );


### PR DESCRIPTION
### WHY are these changes introduced?

Closes #396

Shopify rejects apps that don't return a `401 Unauthorized` response when they receive an invalid HMAC in a webhook request, and the library currently returns 403.

### WHAT is this pull request doing?

Changing the response code in that scenario to 401. Also changing the "handler not found" scenario to return a 404 instead.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
