### PR TITLE
Exclude __tests__ directories in build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,5 +37,5 @@
     "rootDir": "src"
   },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/test/*"]
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/test/*", "**/__tests__/*"],
 }


### PR DESCRIPTION
### WHY are these changes introduced?

`fake-resource.*` and `fake-resource-with-custom-prefix.*` were being included in a `__tests__` directory under `dist` in the published package.

### WHAT is this pull request doing?

Adds `"**/__tests__/*"` to the `exclude` line of `tsconfig.json`

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above - not applicable
- [ ] I have added/updated tests for this change - not applicable
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs) - not applicable
