### PR TITLE
Allow redis options in session storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- Allow passing in options for the Redis client used by the session storage strategy [#430](https://github.com/Shopify/shopify-api-node/pull/430)
+
 ## [4.2.0] - 2022-07-20
 
 - Return a 401 instead of 403 when webhooks fail validation [#425](https://github.com/Shopify/shopify-api-node/pull/425)

--- a/src/auth/session/storage/redis.ts
+++ b/src/auth/session/storage/redis.ts
@@ -1,10 +1,10 @@
-import {createClient, RedisClientType} from 'redis';
+import {createClient, RedisClientType, RedisClientOptions} from 'redis';
 
 import {SessionInterface} from '../types';
 import {SessionStorage} from '../session_storage';
 import {sessionFromEntries, sessionEntries} from '../session-utils';
 
-export interface RedisSessionStorageOptions {
+export interface RedisSessionStorageOptions extends RedisClientOptions {
   sessionKeyPrefix: string;
 }
 const defaultRedisSessionStorageOptions: RedisSessionStorageOptions = {
@@ -103,6 +103,7 @@ export class RedisSessionStorage implements SessionStorage {
 
   private async init() {
     this.client = createClient({
+      ...this.options,
       url: this.dbUrl.toString(),
     });
     await this.client.connect();


### PR DESCRIPTION
### WHY are these changes introduced?

Closes #416

We currently don't allow our session storage strategy for Redis to pass any options to the client it creates, which makes it hard to customize it.

### WHAT is this pull request doing?

Having our internal options used to create the client extend from the default client options, so that we essentially provide any functionality available to the client itself to apps using the library.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
