### PR TITLE
Add handling of `errors` field in GQL response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 - Allow passing in options for the Redis client used by the session storage strategy [#430](https://github.com/Shopify/shopify-api-node/pull/430)
-- If a response from a GraphQL query contains an `errors` attribute, `GraphqlClient` will now throw a `GraphqlQueryError`. The caller can check the `error.response` attribute to see what was returned from the GraphQL API. [#431](https://github.com/Shopify/shopify-api-node/pull/431)
+- ⚠️ [Breaking] If a response from a GraphQL query contains an `errors` attribute, `GraphqlClient` will now throw a `GraphqlQueryError`. The caller can check the `error.response` attribute to see what was returned from the GraphQL API. [#431](https://github.com/Shopify/shopify-api-node/pull/431)
 
 ## [4.2.0] - 2022-07-20
 
@@ -110,12 +110,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Add a 5 second `clockTolerance` to fix `jwt not active` error [#227](https://github.com/Shopify/shopify-api-node/pull/227)
-- [Breaking] Change default for OAuth.beginAuth to online sessions [#203](https://github.com/Shopify/shopify-api-node/pull/203)
+- ⚠️ [Breaking] Change default for OAuth.beginAuth to online sessions [#203](https://github.com/Shopify/shopify-api-node/pull/203)
   - see [oauth.md](https://github.com/Shopify/shopify-api-node/blob/main/docs/usage/oauth.md) for updated docs
-- [Breaking] Return and delete session in `validateAuthCallback` [#217](https://github.com/Shopify/shopify-api-node/pull/217)
+- ⚠️ [Breaking] Return and delete session in `validateAuthCallback` [#217](https://github.com/Shopify/shopify-api-node/pull/217)
   - see [oauth.md](https://github.com/Shopify/shopify-api-node/blob/main/docs/usage/oauth.md) for updated usage
-- [Breaking] Extract `addHandler` and `getHandler` methods for webhooks out of `register` [#205](https://github.com/Shopify/shopify-api-node/pull/205)
-- [Breaking] Sessions no longer default to `false` for `isOnline` [#169](https://github.com/Shopify/shopify-api-node/pull/169)
+- ⚠️ [Breaking] Extract `addHandler` and `getHandler` methods for webhooks out of `register` [#205](https://github.com/Shopify/shopify-api-node/pull/205)
+- ⚠️ [Breaking] Sessions no longer default to `false` for `isOnline` [#169](https://github.com/Shopify/shopify-api-node/pull/169)
 - Required `Session` arguments must be passed to the constructor [#169](https://github.com/Shopify/shopify-api-node/pull/169)
 - Allow `undefined` in `AuthScopes` [#169](https://github.com/Shopify/shopify-api-node/pull/169)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 - Allow passing in options for the Redis client used by the session storage strategy [#430](https://github.com/Shopify/shopify-api-node/pull/430)
+- If a response from a GraphQL query contains an `errors` attribute, `GraphqlClient` will now throw a `GraphqlQueryError`. The caller can check the `error.response` attribute to see what was returned from the GraphQL API. [#431](https://github.com/Shopify/shopify-api-node/pull/431)
 
 ## [4.2.0] - 2022-07-20
 

--- a/docs/usage/graphql.md
+++ b/docs/usage/graphql.md
@@ -83,7 +83,7 @@ try {
   }
 }
 
-// assuming now errors, do something with the returned data...
+// assuming no errors, do something with the returned data...
 ```
 
 [Back to guide index](../README.md)

--- a/docs/usage/graphql.md
+++ b/docs/usage/graphql.md
@@ -55,4 +55,35 @@ const products = await client.query({
   }
 });
 ```
+
+Note that the call to `query` should be wrapped in a `try/catch` block.  If the GraphQL API returns any errors, it will throw `ShopifyErrors.GraphqlQueryError` and provides the response from the API in the `response` attribute.
+
+```ts
+let products;
+try {
+  products = await client.query({
+    data: `{
+        products (first: 10) {
+          edges {
+            node {
+              id
+              title
+              descriptionHtml
+            }
+          }
+        }
+      }`,
+  });
+} catch (error) {
+  if (error instanceof ShopifyErrors.GraphqlQueryError) {
+    // look at error.response for details returned from API,
+    // specifically, error.response.errors[0].message
+  } else {
+    // handle other errors
+  }
+}
+
+// assuming now errors, do something with the returned data...
+```
+
 [Back to guide index](../README.md)

--- a/src/clients/graphql/__tests__/graphql_client.test.ts
+++ b/src/clients/graphql/__tests__/graphql_client.test.ts
@@ -140,6 +140,64 @@ describe('GraphQL client', () => {
       data: JSON.stringify(queryWithVariables),
     }).toMatchMadeHttpRequest();
   });
+
+  it('throws error when response contains an errors field', async () => {
+    const client: GraphqlClient = new GraphqlClient(DOMAIN, 'bork');
+    const query = {
+      query: `query getProducts {
+        products {
+          edges {
+            node {
+              id
+            }
+          }
+        }
+      }`,
+    };
+
+    const errorResponse = {
+      data: null,
+      errors: [
+        {
+          message: 'you must provide one of first or last',
+          locations: [
+            {
+              line: 2,
+              column: 3,
+            },
+          ],
+          path: ['products'],
+        },
+      ],
+      extensions: {
+        cost: {
+          requestedQueryCost: 2,
+          actualQueryCost: 2,
+          throttleStatus: {
+            maximumAvailable: 1000,
+            currentlyAvailable: 998,
+            restoreRate: 50,
+          },
+        },
+      },
+    };
+
+    fetchMock.mockResponseOnce(JSON.stringify(errorResponse));
+
+    await expect(() => client.query({data: query})).rejects.toThrowError();
+
+    expect({
+      method: 'POST',
+      domain: DOMAIN,
+      path: '/admin/api/unstable/graphql.json',
+      headers: {
+        'Content-Length': 156,
+        'Content-Type': 'application/json',
+        'X-Shopify-Access-Token': 'bork',
+      },
+      data: JSON.stringify(query),
+    }).toMatchMadeHttpRequest();
+  });
 });
 
 function buildExpectedResponse(obj: unknown) {

--- a/src/clients/graphql/__tests__/graphql_client.test.ts
+++ b/src/clients/graphql/__tests__/graphql_client.test.ts
@@ -184,7 +184,12 @@ describe('GraphQL client', () => {
 
     fetchMock.mockResponseOnce(JSON.stringify(errorResponse));
 
-    await expect(() => client.query({data: query})).rejects.toThrowError();
+    await expect(() => client.query({data: query})).rejects.toThrow(
+      new ShopifyErrors.GraphqlQueryError({
+        message: 'GraphQL query returned errors',
+        response: errorResponse,
+      }),
+    );
 
     expect({
       method: 'POST',

--- a/src/clients/graphql/graphql_client.ts
+++ b/src/clients/graphql/graphql_client.ts
@@ -1,4 +1,3 @@
-import {MissingRequiredArgument} from '../../error';
 import {Context} from '../../context';
 import {ShopifyHeader} from '../../base-types';
 import {HttpClient} from '../http_client/http_client';
@@ -29,7 +28,7 @@ export class GraphqlClient {
 
   async query(params: GraphqlParams): Promise<RequestReturn> {
     if (params.data.length === 0) {
-      throw new MissingRequiredArgument('Query missing.');
+      throw new ShopifyErrors.MissingRequiredArgument('Query missing.');
     }
 
     const accessTokenHeader = this.getAccessTokenHeader();

--- a/src/clients/graphql/graphql_client.ts
+++ b/src/clients/graphql/graphql_client.ts
@@ -51,9 +51,10 @@ export class GraphqlClient {
     const result = await this.client.post({path, type: dataType, ...params});
 
     if ((result.body as {[key: string]: unknown}).errors) {
-      throw new ShopifyErrors.GraphqlQueryError(
-        `GraphQL query returned errors: ${JSON.stringify(result.body)}`,
-      );
+      throw new ShopifyErrors.GraphqlQueryError({
+        message: 'GraphQL query returned errors',
+        response: result.body as {[key: string]: unknown},
+      });
     }
     return result;
   }

--- a/src/clients/graphql/graphql_client.ts
+++ b/src/clients/graphql/graphql_client.ts
@@ -48,7 +48,14 @@ export class GraphqlClient {
       dataType = DataType.GraphQL;
     }
 
-    return this.client.post({path, type: dataType, ...params});
+    const result = await this.client.post({path, type: dataType, ...params});
+
+    if ((result.body as {[key: string]: unknown}).errors) {
+      throw new ShopifyErrors.GraphqlQueryError(
+        `GraphQL query returned errors: ${JSON.stringify(result.body)}`,
+      );
+    }
+    return result;
   }
 
   protected getAccessTokenHeader(): AccessTokenHeader {

--- a/src/error.ts
+++ b/src/error.ts
@@ -64,6 +64,7 @@ export class HttpThrottlingError extends HttpRetriableError {
 }
 
 export class RestResourceError extends ShopifyError {}
+export class GraphqlQueryError extends ShopifyError {}
 
 export class InvalidOAuthError extends ShopifyError {}
 export class SessionNotFound extends ShopifyError {}

--- a/src/error.ts
+++ b/src/error.ts
@@ -64,7 +64,20 @@ export class HttpThrottlingError extends HttpRetriableError {
 }
 
 export class RestResourceError extends ShopifyError {}
-export class GraphqlQueryError extends ShopifyError {}
+export class GraphqlQueryError extends ShopifyError {
+  readonly response: {[key: string]: unknown};
+
+  public constructor({
+    message,
+    response,
+  }: {
+    message: string;
+    response: {[key: string]: unknown};
+  }) {
+    super(message);
+    this.response = response;
+  }
+}
 
 export class InvalidOAuthError extends ShopifyError {}
 export class SessionNotFound extends ShopifyError {}

--- a/src/webhooks/registry.ts
+++ b/src/webhooks/registry.ts
@@ -268,18 +268,9 @@ const WebhooksRegistry: RegistryInterface = {
         data: buildCheckQuery(topic),
       })) as {body: WebhookCheckResponse};
     } catch (error) {
-      if (error instanceof ShopifyErrors.GraphqlQueryError) {
-        registerReturn[topic] = {
-          success: false,
-          result: error.response,
-        };
-      } else {
-        registerReturn[topic] = {
-          success: false,
-          result: {},
-        };
-      }
-
+      const result =
+        error instanceof ShopifyErrors.GraphqlQueryError ? error.response : {};
+      registerReturn[topic] = {success: false, result};
       return registerReturn;
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

GraphQL will return 200 OK even if there was an issue with the GraphQL query.

API lib part of https://github.com/Shopify/first-party-library-planning/issues/385

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This change adds a check to see if the response contains an `errors` field and will throw `GraphqlQueryError` if it does. It also includes a stringified version of the response body in the error.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [x] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
