### PR TITLE
Fixes return type of loadSession in Custom Session Storage strategy

### DIFF
--- a/src/auth/session/storage/custom.ts
+++ b/src/auth/session/storage/custom.ts
@@ -61,6 +61,7 @@ export class CustomSessionStorage implements SessionStorage {
           session.expires = new Date(session.expires);
         }
 
+        Object.setPrototypeOf(session, Session.prototype);
         return session as SessionInterface;
       } else {
         throw new ShopifyErrors.SessionStorageError(


### PR DESCRIPTION
### WHY are these changes introduced?

If stored session is a mere object, need to set the prototype to the Session type prior to return.

Fixes https://github.com/Shopify/shopify-api-node/issues/423

### WHAT is this pull request doing?

Call `Object.setPrototype(session, Session.prototype)` prior to returning `session` in `loadSession`.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
