### PR TITLE
Add methods to sanitize shops and hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-- Allow passing in options for the Redis client used by the session storage strategy [#430](https://github.com/Shopify/shopify-api-node/pull/430)
 - ⚠️ [Breaking] If a response from a GraphQL query contains an `errors` attribute, `GraphqlClient` will now throw a `GraphqlQueryError`. The caller can check the `error.response` attribute to see what was returned from the GraphQL API. [#431](https://github.com/Shopify/shopify-api-node/pull/431)
+- Allow passing in options for the Redis client used by the session storage strategy [#430](https://github.com/Shopify/shopify-api-node/pull/430)
+- Add utils functions to sanitize shops and hosts [#434](https://github.com/Shopify/shopify-api-node/pull/434)
 
 ## [4.2.0] - 2022-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 - ⚠️ [Breaking] If a response from a GraphQL query contains an `errors` attribute, `GraphqlClient` will now throw a `GraphqlQueryError`. The caller can check the `error.response` attribute to see what was returned from the GraphQL API. [#431](https://github.com/Shopify/shopify-api-node/pull/431)
-- Allow passing in options for the Redis client used by the session storage strategy [#430](https://github.com/Shopify/shopify-api-node/pull/430)
 - ⚠️ [Breaking] Add utils functions to sanitize shops and hosts, and remove the `validateShop` utils function [#434](https://github.com/Shopify/shopify-api-node/pull/434)
+- Allow passing in options for the Redis client used by the session storage strategy [#430](https://github.com/Shopify/shopify-api-node/pull/430)
 
 ## [4.2.0] - 2022-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - ⚠️ [Breaking] If a response from a GraphQL query contains an `errors` attribute, `GraphqlClient` will now throw a `GraphqlQueryError`. The caller can check the `error.response` attribute to see what was returned from the GraphQL API. [#431](https://github.com/Shopify/shopify-api-node/pull/431)
 - Allow passing in options for the Redis client used by the session storage strategy [#430](https://github.com/Shopify/shopify-api-node/pull/430)
-- Add utils functions to sanitize shops and hosts [#434](https://github.com/Shopify/shopify-api-node/pull/434)
+- ⚠️ [Breaking] Add utils functions to sanitize shops and hosts, and remove the `validateShop` utils function [#434](https://github.com/Shopify/shopify-api-node/pull/434)
 
 ## [4.2.0] - 2022-07-20
 

--- a/docs/usage/utils.md
+++ b/docs/usage/utils.md
@@ -5,10 +5,24 @@
 If you need to redirect a request to your embedded app URL you can use `getEmbeddedAppUrl`
 
 ```ts
-const redirectURL = getEmbeddedAppUrl(request);
+const redirectURL = Shopify.Utils.getEmbeddedAppUrl(request);
 res.redirect(redirectURL);
 ```
 
-Using this utility ensures that embedded app URL is properly constructed and brings the merchant to the right place.  It is more reliable than using the shop param.
+Using this utility ensures that embedded app URL is properly constructed and brings the merchant to the right place. It is more reliable than using the shop param.
 
 This utility relies on the host query param being a Base 64 encoded string. All requests from Shopify should include this param in the correct format.
+
+## Sanitize a Shopify shop domain and host address
+
+When receiving input from users, like in URL query arguments, you should always make sure to sanitize that data.
+To make it easier to do that, this library provides the following methods:
+
+```ts
+const shop = Shopify.Utils.sanitizeShop(req.query.shop, true);
+const host = Shopify.Utils.sanitizeHost(req.query.host, true);
+```
+
+Both of these return the string itself if it's valid, or `null` otherwise.
+You can also optionally set the method to throw an exception if the validation fails.
+If you're using custom shop domains for testing, you can add them to the `Shopify.Context.CUSTOM_SHOP_DOMAINS` setting.

--- a/src/auth/oauth/__tests__/oauth.test.ts
+++ b/src/auth/oauth/__tests__/oauth.test.ts
@@ -237,7 +237,12 @@ describe('validateAuthCallback', () => {
   });
 
   test('throws an error when receiving a callback for a shop with no saved session', async () => {
-    await ShopifyOAuth.beginAuth(req, res, 'invalidurl.com', '/some-callback');
+    await ShopifyOAuth.beginAuth(
+      req,
+      res,
+      'test-shop.myshopify.io',
+      '/some-callback',
+    );
 
     await Context.SESSION_STORAGE.deleteSession(cookies.id);
 
@@ -249,7 +254,12 @@ describe('validateAuthCallback', () => {
   });
 
   test('throws error when callback includes invalid hmac, or state', async () => {
-    await ShopifyOAuth.beginAuth(req, res, 'invalidurl.com', '/some-callback');
+    await ShopifyOAuth.beginAuth(
+      req,
+      res,
+      'test-shop.myshopify.io',
+      '/some-callback',
+    );
     const testCallbackQuery: AuthQuery = {
       shop: 'invalidurl.com',
       state: 'incorrect',

--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -46,7 +46,7 @@ const ShopifyOAuth = {
   ): Promise<string> {
     Context.throwIfUninitialized();
     Context.throwIfPrivateApp('Cannot perform OAuth for private apps');
-    sanitizeShop(shop, true);
+    const cleanShop = sanitizeShop(shop, true)!;
 
     const cookies = new Cookies(request, response, {
       keys: [Context.API_SECRET_KEY],
@@ -56,8 +56,8 @@ const ShopifyOAuth = {
     const state = nonce();
 
     const session = new Session(
-      isOnline ? uuidv4() : this.getOfflineSessionId(shop),
-      shop,
+      isOnline ? uuidv4() : this.getOfflineSessionId(cleanShop),
+      cleanShop,
       state,
       isOnline,
     );
@@ -89,7 +89,7 @@ const ShopifyOAuth = {
 
     const queryString = querystring.stringify(query);
 
-    return `https://${shop}/admin/oauth/authorize?${queryString}`;
+    return `https://${cleanShop}/admin/oauth/authorize?${queryString}`;
   },
 
   /**

--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -14,6 +14,7 @@ import {HttpClient} from '../../clients/http_client/http_client';
 import {DataType} from '../../clients/http_client/types';
 import * as ShopifyErrors from '../../error';
 import {SessionInterface} from '../session/types';
+import {sanitizeShop} from '../../utils/shop-validator';
 
 import {
   AuthQuery,
@@ -45,6 +46,7 @@ const ShopifyOAuth = {
   ): Promise<string> {
     Context.throwIfUninitialized();
     Context.throwIfPrivateApp('Cannot perform OAuth for private apps');
+    sanitizeShop(shop, true);
 
     const cookies = new Cookies(request, response, {
       keys: [Context.API_SECRET_KEY],
@@ -232,7 +234,7 @@ const ShopifyOAuth = {
    * @param userId Current actor id
    */
   getJwtSessionId(shop: string, userId: string): string {
-    return `${shop}_${userId}`;
+    return `${sanitizeShop(shop, true)}_${userId}`;
   },
 
   /**
@@ -241,7 +243,7 @@ const ShopifyOAuth = {
    * @param shop Shopify shop domain
    */
   getOfflineSessionId(shop: string): string {
-    return `offline_${shop}`;
+    return `offline_${sanitizeShop(shop, true)}`;
   },
 
   /**

--- a/src/auth/session/storage/__tests__/battery-of-tests.ts
+++ b/src/auth/session/storage/__tests__/battery-of-tests.ts
@@ -106,10 +106,30 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
     const storage = await storageFactory();
     const prefix = 'find_sessions';
     const sessions = [
-      new Session(`${prefix}_1`, 'find-shop1-sessions', 'state', true),
-      new Session(`${prefix}_2`, 'do-not-find-shop2-sessions', 'state', true),
-      new Session(`${prefix}_3`, 'find-shop1-sessions', 'state', true),
-      new Session(`${prefix}_4`, 'do-not-find-shop3-sessions', 'state', true),
+      new Session(
+        `${prefix}_1`,
+        'find-shop1-sessions.myshopify.io',
+        'state',
+        true,
+      ),
+      new Session(
+        `${prefix}_2`,
+        'do-not-find-shop2-sessions.myshopify.io',
+        'state',
+        true,
+      ),
+      new Session(
+        `${prefix}_3`,
+        'find-shop1-sessions.myshopify.io',
+        'state',
+        true,
+      ),
+      new Session(
+        `${prefix}_4`,
+        'do-not-find-shop3-sessions.myshopify.io',
+        'state',
+        true,
+      ),
     ];
 
     for (const session of sessions) {
@@ -118,7 +138,7 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
     expect(storage.findSessionsByShop).toBeDefined();
     if (storage.findSessionsByShop) {
       const shop1Sessions = await storage.findSessionsByShop(
-        'find-shop1-sessions',
+        'find-shop1-sessions.myshopify.io',
       );
       expect(shop1Sessions).toBeDefined();
       if (shop1Sessions) {
@@ -137,10 +157,30 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
     const storage = await storageFactory();
     const prefix = 'delete_sessions';
     const sessions = [
-      new Session(`${prefix}_1`, 'delete-shop1-sessions', 'state', true),
-      new Session(`${prefix}_2`, 'do-not-delete-shop2-sessions', 'state', true),
-      new Session(`${prefix}_3`, 'delete-shop1-sessions', 'state', true),
-      new Session(`${prefix}_4`, 'do-not-delete-shop3-sessions', 'state', true),
+      new Session(
+        `${prefix}_1`,
+        'delete-shop1-sessions.myshopify.io',
+        'state',
+        true,
+      ),
+      new Session(
+        `${prefix}_2`,
+        'do-not-delete-shop2-sessions.myshopify.io',
+        'state',
+        true,
+      ),
+      new Session(
+        `${prefix}_3`,
+        'delete-shop1-sessions.myshopify.io',
+        'state',
+        true,
+      ),
+      new Session(
+        `${prefix}_4`,
+        'do-not-delete-shop3-sessions.myshopify.io',
+        'state',
+        true,
+      ),
     ];
 
     for (const session of sessions) {
@@ -149,7 +189,7 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
     expect(storage.deleteSessions).toBeDefined();
     if (storage.deleteSessions && storage.findSessionsByShop) {
       let shop1Sessions = await storage.findSessionsByShop(
-        'delete-shop1-sessions',
+        'delete-shop1-sessions.myshopify.io',
       );
       expect(shop1Sessions).toBeDefined();
       if (shop1Sessions) {
@@ -157,7 +197,7 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
         const idsToDelete = shop1Sessions.map((session) => session.id);
         await expect(storage.deleteSessions(idsToDelete)).resolves.toBe(true);
         shop1Sessions = await storage.findSessionsByShop(
-          'delete-shop1-sessions',
+          'delete-shop1-sessions.myshopify.io',
         );
         expect(shop1Sessions).toEqual([]);
       }

--- a/src/auth/session/storage/__tests__/custom.test.ts
+++ b/src/auth/session/storage/__tests__/custom.test.ts
@@ -59,10 +59,10 @@ describe('custom session storage', () => {
   test('can perform optional actions', async () => {
     const prefix = 'custom_sessions';
     let sessions = [
-      new Session(`${prefix}_1`, 'shop1-sessions', 'state', true),
-      new Session(`${prefix}_2`, 'shop2-sessions', 'state', true),
-      new Session(`${prefix}_3`, 'shop1-sessions', 'state', true),
-      new Session(`${prefix}_4`, 'shop3-sessions', 'state', true),
+      new Session(`${prefix}_1`, 'shop1-sessions.myshopify.io', 'state', true),
+      new Session(`${prefix}_2`, 'shop2-sessions.myshopify.io', 'state', true),
+      new Session(`${prefix}_3`, 'shop1-sessions.myshopify.io', 'state', true),
+      new Session(`${prefix}_4`, 'shop3-sessions.myshopify.io', 'state', true),
     ];
 
     let deleteSessionsCalled = false;
@@ -93,7 +93,7 @@ describe('custom session storage', () => {
     );
 
     await expect(
-      storage.findSessionsByShop('shop1_sessinons'),
+      storage.findSessionsByShop('shop1_sessions.myshopify.io'),
     ).resolves.toEqual([sessions[0], sessions[2]]);
     expect(findSessionsByShopCalled).toBe(true);
 
@@ -103,14 +103,19 @@ describe('custom session storage', () => {
     expect(deleteSessionsCalled).toBe(true);
     expect(sessions.length).toBe(2);
     await expect(
-      storage.findSessionsByShop('shop1_sessinons'),
+      storage.findSessionsByShop('shop1_sessions.myshopify.io'),
     ).resolves.toEqual([]);
   });
 
   test('missing optional actions generate warnings', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const prefix = 'custom_sessions';
-    const session = new Session(`${prefix}_1`, 'shop1-sessions', 'state', true);
+    const session = new Session(
+      `${prefix}_1`,
+      'shop1-sessions.myshopify.io',
+      'state',
+      true,
+    );
 
     const storage = new CustomSessionStorage(
       () => {
@@ -125,7 +130,7 @@ describe('custom session storage', () => {
     );
 
     await expect(
-      storage.findSessionsByShop('shop1_sessinons'),
+      storage.findSessionsByShop('shop1_sessions.myshopify.io'),
     ).resolves.toEqual([]);
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('findSessionsByShopCallback not defined.'),
@@ -141,7 +146,12 @@ describe('custom session storage', () => {
 
   test('failures and exceptions are raised', () => {
     const sessionId = 'test_session';
-    const session = new Session(sessionId, 'shop-url', 'state', true);
+    const session = new Session(
+      sessionId,
+      'shop-url.myshopify.io',
+      'state',
+      true,
+    );
 
     let storage = new CustomSessionStorage(
       () => Promise.resolve(false),
@@ -272,7 +282,7 @@ describe('custom session storage', () => {
 
     let session: Session | undefined = new Session(
       sessionId,
-      'shop',
+      'shop.myshopify.io',
       'state',
       true,
     );

--- a/src/auth/session/storage/custom.ts
+++ b/src/auth/session/storage/custom.ts
@@ -104,13 +104,13 @@ export class CustomSessionStorage implements SessionStorage {
   }
 
   public async findSessionsByShop(shop: string): Promise<SessionInterface[]> {
-    sanitizeShop(shop, true);
+    const cleanShop = sanitizeShop(shop, true)!;
 
     let sessions: SessionInterface[] = [];
 
     if (this.findSessionsByShopCallback) {
       try {
-        sessions = await this.findSessionsByShopCallback(shop);
+        sessions = await this.findSessionsByShopCallback(cleanShop);
       } catch (error) {
         throw new ShopifyErrors.SessionStorageError(
           `CustomSessionStorage failed to find sessions by shop. Error Details: ${error}`,

--- a/src/auth/session/storage/custom.ts
+++ b/src/auth/session/storage/custom.ts
@@ -2,6 +2,7 @@ import {Session} from '../session';
 import {SessionInterface} from '../types';
 import {SessionStorage} from '../session_storage';
 import * as ShopifyErrors from '../../../error';
+import {sanitizeShop} from '../../../utils/shop-validator';
 
 export class CustomSessionStorage implements SessionStorage {
   constructor(
@@ -103,6 +104,8 @@ export class CustomSessionStorage implements SessionStorage {
   }
 
   public async findSessionsByShop(shop: string): Promise<SessionInterface[]> {
+    sanitizeShop(shop, true);
+
     let sessions: SessionInterface[] = [];
 
     if (this.findSessionsByShopCallback) {

--- a/src/auth/session/storage/memory.ts
+++ b/src/auth/session/storage/memory.ts
@@ -27,10 +27,10 @@ export class MemorySessionStorage implements SessionStorage {
   }
 
   public async findSessionsByShop(shop: string): Promise<SessionInterface[]> {
-    sanitizeShop(shop, true);
+    const cleanShop = sanitizeShop(shop, true)!;
 
     const results = Object.values(this.sessions).filter(
-      (session) => session.shop === shop,
+      (session) => session.shop === cleanShop,
     );
     return results;
   }

--- a/src/auth/session/storage/memory.ts
+++ b/src/auth/session/storage/memory.ts
@@ -1,5 +1,6 @@
 import {SessionInterface} from '../types';
 import {SessionStorage} from '../session_storage';
+import {sanitizeShop} from '../../../utils/shop-validator';
 
 export class MemorySessionStorage implements SessionStorage {
   private sessions: {[id: string]: SessionInterface} = {};
@@ -26,6 +27,8 @@ export class MemorySessionStorage implements SessionStorage {
   }
 
   public async findSessionsByShop(shop: string): Promise<SessionInterface[]> {
+    sanitizeShop(shop, true);
+
     const results = Object.values(this.sessions).filter(
       (session) => session.shop === shop,
     );

--- a/src/auth/session/storage/mongodb.ts
+++ b/src/auth/session/storage/mongodb.ts
@@ -83,9 +83,9 @@ export class MongoDBSessionStorage implements SessionStorage {
 
   public async findSessionsByShop(shop: string): Promise<SessionInterface[]> {
     await this.ready;
-    sanitizeShop(shop, true);
+    const cleanShop = sanitizeShop(shop, true)!;
 
-    const rawResults = await this.collection.find({shop}).toArray();
+    const rawResults = await this.collection.find({shop: cleanShop}).toArray();
     if (!rawResults || rawResults?.length === 0) return [];
 
     return rawResults.map((rawResult: any) =>

--- a/src/auth/session/storage/mongodb.ts
+++ b/src/auth/session/storage/mongodb.ts
@@ -3,6 +3,7 @@ import * as mongodb from 'mongodb';
 import {SessionInterface} from '../types';
 import {SessionStorage} from '../session_storage';
 import {sessionFromEntries, sessionEntries} from '../session-utils';
+import {sanitizeShop} from '../../../utils/shop-validator';
 
 export interface MongoDBSessionStorageOptions {
   sessionCollectionName: string;
@@ -82,6 +83,7 @@ export class MongoDBSessionStorage implements SessionStorage {
 
   public async findSessionsByShop(shop: string): Promise<SessionInterface[]> {
     await this.ready;
+    sanitizeShop(shop, true);
 
     const rawResults = await this.collection.find({shop}).toArray();
     if (!rawResults || rawResults?.length === 0) return [];

--- a/src/auth/session/storage/mysql.ts
+++ b/src/auth/session/storage/mysql.ts
@@ -3,6 +3,7 @@ import mysql from 'mysql2/promise';
 import {SessionInterface} from '../types';
 import {SessionStorage} from '../session_storage';
 import {sessionFromEntries, sessionEntries} from '../session-utils';
+import {sanitizeShop} from '../../../utils/shop-validator';
 
 export interface MySQLSessionStorageOptions {
   sessionTableName: string;
@@ -94,6 +95,8 @@ export class MySQLSessionStorage implements SessionStorage {
 
   public async findSessionsByShop(shop: string): Promise<SessionInterface[]> {
     await this.ready;
+    sanitizeShop(shop, true);
+
     const query = `
       SELECT * FROM ${this.options.sessionTableName}
       WHERE shop = ?;

--- a/src/auth/session/storage/mysql.ts
+++ b/src/auth/session/storage/mysql.ts
@@ -95,13 +95,13 @@ export class MySQLSessionStorage implements SessionStorage {
 
   public async findSessionsByShop(shop: string): Promise<SessionInterface[]> {
     await this.ready;
-    sanitizeShop(shop, true);
+    const cleanShop = sanitizeShop(shop, true)!;
 
     const query = `
       SELECT * FROM ${this.options.sessionTableName}
       WHERE shop = ?;
     `;
-    const [rows] = await this.query(query, [shop]);
+    const [rows] = await this.query(query, [cleanShop]);
     if (!Array.isArray(rows) || rows?.length === 0) return [];
 
     const results: SessionInterface[] = rows.map((row) => {

--- a/src/auth/session/storage/postgresql.ts
+++ b/src/auth/session/storage/postgresql.ts
@@ -3,6 +3,7 @@ import pg from 'pg';
 import {SessionInterface} from '../types';
 import {SessionStorage} from '../session_storage';
 import {sessionEntries, sessionFromEntries} from '../session-utils';
+import {sanitizeShop} from '../../../utils/shop-validator';
 
 export interface PostgreSQLSessionStorageOptions {
   sessionTableName: string;
@@ -100,6 +101,8 @@ export class PostgreSQLSessionStorage implements SessionStorage {
 
   public async findSessionsByShop(shop: string): Promise<SessionInterface[]> {
     await this.ready;
+    sanitizeShop(shop, true);
+
     const query = `
       SELECT * FROM ${this.options.sessionTableName}
       WHERE shop = $1;

--- a/src/auth/session/storage/postgresql.ts
+++ b/src/auth/session/storage/postgresql.ts
@@ -101,13 +101,13 @@ export class PostgreSQLSessionStorage implements SessionStorage {
 
   public async findSessionsByShop(shop: string): Promise<SessionInterface[]> {
     await this.ready;
-    sanitizeShop(shop, true);
+    const cleanShop = sanitizeShop(shop, true)!;
 
     const query = `
       SELECT * FROM ${this.options.sessionTableName}
       WHERE shop = $1;
     `;
-    const rows = await this.query(query, [shop]);
+    const rows = await this.query(query, [cleanShop]);
     if (!Array.isArray(rows) || rows?.length === 0) return [];
 
     const results: SessionInterface[] = rows.map((row) => {

--- a/src/auth/session/storage/redis.ts
+++ b/src/auth/session/storage/redis.ts
@@ -3,6 +3,7 @@ import {createClient, RedisClientType, RedisClientOptions} from 'redis';
 import {SessionInterface} from '../types';
 import {SessionStorage} from '../session_storage';
 import {sessionFromEntries, sessionEntries} from '../session-utils';
+import {sanitizeShop} from '../../../utils/shop-validator';
 
 export interface RedisSessionStorageOptions extends RedisClientOptions {
   sessionKeyPrefix: string;
@@ -79,6 +80,7 @@ export class RedisSessionStorage implements SessionStorage {
 
   public async findSessionsByShop(shop: string): Promise<SessionInterface[]> {
     await this.ready;
+    sanitizeShop(shop, true);
 
     const keys = await this.client.keys('*');
     const results: SessionInterface[] = [];

--- a/src/auth/session/storage/redis.ts
+++ b/src/auth/session/storage/redis.ts
@@ -80,7 +80,7 @@ export class RedisSessionStorage implements SessionStorage {
 
   public async findSessionsByShop(shop: string): Promise<SessionInterface[]> {
     await this.ready;
-    sanitizeShop(shop, true);
+    const cleanShop = sanitizeShop(shop, true)!;
 
     const keys = await this.client.keys('*');
     const results: SessionInterface[] = [];
@@ -89,7 +89,7 @@ export class RedisSessionStorage implements SessionStorage {
       if (!rawResult) continue;
 
       const session = sessionFromEntries(JSON.parse(rawResult));
-      if (session.shop === shop) results.push(session);
+      if (session.shop === cleanShop) results.push(session);
     }
 
     return results;

--- a/src/auth/session/storage/sqlite.ts
+++ b/src/auth/session/storage/sqlite.ts
@@ -3,6 +3,7 @@ import sqlite3 from 'sqlite3';
 import {SessionInterface} from '../types';
 import {SessionStorage} from '../session_storage';
 import {sessionFromEntries, sessionEntries} from '../session-utils';
+import {sanitizeShop} from '../../../utils/shop-validator';
 
 export interface SQLiteSessionStorageOptions {
   sessionTableName: string;
@@ -77,6 +78,8 @@ export class SQLiteSessionStorage implements SessionStorage {
   }
 
   public async findSessionsByShop(shop: string): Promise<SessionInterface[]> {
+    sanitizeShop(shop, true);
+
     await this.ready;
     const query = `
       SELECT * FROM ${this.options.sessionTableName}

--- a/src/auth/session/storage/sqlite.ts
+++ b/src/auth/session/storage/sqlite.ts
@@ -78,14 +78,14 @@ export class SQLiteSessionStorage implements SessionStorage {
   }
 
   public async findSessionsByShop(shop: string): Promise<SessionInterface[]> {
-    sanitizeShop(shop, true);
+    const cleanShop = sanitizeShop(shop, true)!;
 
     await this.ready;
     const query = `
       SELECT * FROM ${this.options.sessionTableName}
       WHERE shop = ?;
     `;
-    const rows = await this.query(query, [shop]);
+    const rows = await this.query(query, [cleanShop]);
     if (!Array.isArray(rows) || rows?.length === 0) return [];
 
     const results: SessionInterface[] = rows.map((row) => {

--- a/src/base-types.ts
+++ b/src/base-types.ts
@@ -14,6 +14,7 @@ export interface ContextParams {
   LOG_FILE?: string;
   USER_AGENT_PREFIX?: string;
   PRIVATE_APP_STOREFRONT_ACCESS_TOKEN?: string;
+  CUSTOM_SHOP_DOMAINS?: (RegExp | string)[];
 }
 
 export enum ApiVersion {

--- a/src/context.ts
+++ b/src/context.ts
@@ -104,6 +104,10 @@ const Context: ContextInterface = {
       this.PRIVATE_APP_STOREFRONT_ACCESS_TOKEN =
         params.PRIVATE_APP_STOREFRONT_ACCESS_TOKEN;
     }
+
+    if (params.CUSTOM_SHOP_DOMAINS) {
+      this.CUSTOM_SHOP_DOMAINS = params.CUSTOM_SHOP_DOMAINS;
+    }
   },
 
   throwIfUninitialized(): void {

--- a/src/error.ts
+++ b/src/error.ts
@@ -7,6 +7,7 @@ export class ShopifyError extends Error {
 
 export class InvalidHmacError extends ShopifyError {}
 export class InvalidShopError extends ShopifyError {}
+export class InvalidHostError extends ShopifyError {}
 export class InvalidJwtError extends ShopifyError {}
 export class MissingJwtTokenError extends ShopifyError {}
 

--- a/src/utils/__tests__/get-embedded-app-url.test.ts
+++ b/src/utils/__tests__/get-embedded-app-url.test.ts
@@ -39,6 +39,19 @@ describe('getEmbeddedAppUrl', () => {
     );
   });
 
+  test('throws an error when the host query param is invalid', () => {
+    const req = {
+      url: '/?shop=test.myshopify.com&host=test.myshopify.com',
+      headers: {
+        host: 'test.myshopify.com',
+      },
+    } as http.IncomingMessage;
+
+    expect(() => getEmbeddedAppUrl(req)).toThrow(
+      ShopifyErrors.InvalidRequestError,
+    );
+  });
+
   test('returns the host app url', () => {
     const host = 'test.myshopify.com/admin';
     const base64Host = Buffer.from(host, 'utf-8').toString('base64');

--- a/src/utils/__tests__/shop-validator.test.ts
+++ b/src/utils/__tests__/shop-validator.test.ts
@@ -1,6 +1,6 @@
 import {Context} from '../../context';
 import {InvalidShopError} from '../../error';
-import validateShop, {sanitizeHost, sanitizeShop} from '../shop-validator';
+import {sanitizeHost, sanitizeShop} from '../shop-validator';
 
 const VALID_SHOP_URL_1 = 'someshop.myshopify.com';
 const VALID_SHOP_URL_2 = 'devshop.myshopify.io';
@@ -29,24 +29,6 @@ const INVALID_HOST_1 = 'plain-string-is-not-base64';
 const INVALID_HOST_2 = `${Buffer.from(
   'my-other-host.myshopify.com/admin',
 ).toString('base64')}-nope`;
-
-describe('validateShop', () => {
-  test('returns true for valid shop URLs', () => {
-    expect(validateShop(VALID_SHOP_URL_1)).toBe(true);
-    expect(validateShop(VALID_SHOP_URL_2)).toBe(true);
-    expect(validateShop(VALID_SHOP_URL_3)).toBe(true);
-    expect(validateShop(VALID_SHOP_URL_4)).toBe(true);
-  });
-
-  test('returns false for invalid shop URLs', () => {
-    expect(validateShop(INVALID_SHOP_URL_1)).toBe(false);
-    expect(validateShop(INVALID_SHOP_URL_2)).toBe(false);
-  });
-
-  test("returns false for invalid shop URLs, even if they contain the string 'myshopify.io'", () => {
-    expect(validateShop(`${VALID_SHOP_URL_1}.org/potato`)).toBe(false);
-  });
-});
 
 describe('sanitizeShop', () => {
   test('returns the shop for valid URLs', () => {

--- a/src/utils/__tests__/shop-validator.test.ts
+++ b/src/utils/__tests__/shop-validator.test.ts
@@ -1,25 +1,98 @@
-import validateShop from '../shop-validator';
+import {Context} from '../../context';
+import {InvalidShopError} from '../../error';
+import validateShop, {sanitizeHost, sanitizeShop} from '../shop-validator';
 
-test('returns true for valid shop urls', () => {
-  const shopUrl1 = 'someshop.myshopify.com';
-  const shopUrl2 = 'devshop.myshopify.io';
-  const shopUrl3 = 'test-shop.myshopify.com';
-  const shopUrl4 = 'dev-shop-.myshopify.io';
+const VALID_SHOP_URL_1 = 'someshop.myshopify.com';
+const VALID_SHOP_URL_2 = 'devshop.myshopify.io';
+const VALID_SHOP_URL_3 = 'test-shop.myshopify.com';
+const VALID_SHOP_URL_4 = 'dev-shop-.myshopify.io';
 
-  expect(validateShop(shopUrl1)).toBe(true);
-  expect(validateShop(shopUrl2)).toBe(true);
-  expect(validateShop(shopUrl3)).toBe(true);
-  expect(validateShop(shopUrl4)).toBe(true);
+const INVALID_SHOP_URL_1 = 'notshopify.com';
+const INVALID_SHOP_URL_2 = '-invalid.myshopify.io';
+
+const CUSTOM_DOMAIN = 'my-custom-domain.com';
+const VALID_SHOP_WITH_CUSTOM_DOMAIN = `my-shop.${CUSTOM_DOMAIN}`;
+const INVALID_SHOP_WITH_CUSTOM_DOMAIN = `my-shop.${CUSTOM_DOMAIN}.nope`;
+
+const CUSTOM_DOMAIN_REGEX = /my-other-custom-domain\.com/;
+const VALID_SHOP_WITH_CUSTOM_DOMAIN_REGEX = `my-shop.my-other-custom-domain.com`;
+const INVALID_SHOP_WITH_CUSTOM_DOMAIN_REGEX = `my-shop.my-other-custom-domain.com.nope`;
+
+const VALID_HOST_1 = Buffer.from('my-host.myshopify.com/admin').toString(
+  'base64',
+);
+const VALID_HOST_2 = Buffer.from('my-other-host.myshopify.com/admin').toString(
+  'base64',
+);
+
+const INVALID_HOST_1 = 'plain-string-is-not-base64';
+const INVALID_HOST_2 = `${Buffer.from(
+  'my-other-host.myshopify.com/admin',
+).toString('base64')}-nope`;
+
+describe('validateShop', () => {
+  test('returns true for valid shop URLs', () => {
+    expect(validateShop(VALID_SHOP_URL_1)).toBe(true);
+    expect(validateShop(VALID_SHOP_URL_2)).toBe(true);
+    expect(validateShop(VALID_SHOP_URL_3)).toBe(true);
+    expect(validateShop(VALID_SHOP_URL_4)).toBe(true);
+  });
+
+  test('returns false for invalid shop URLs', () => {
+    expect(validateShop(INVALID_SHOP_URL_1)).toBe(false);
+    expect(validateShop(INVALID_SHOP_URL_2)).toBe(false);
+  });
+
+  test("returns false for invalid shop URLs, even if they contain the string 'myshopify.io'", () => {
+    expect(validateShop(`${VALID_SHOP_URL_1}.org/potato`)).toBe(false);
+  });
 });
 
-test('returns false for invalid shop urls', () => {
-  const shopUrl = 'notshopify.com';
-  const anotherShop = '-invalid.myshopify.io';
-  expect(validateShop(shopUrl)).toBe(false);
-  expect(validateShop(anotherShop)).toBe(false);
+describe('sanitizeShop', () => {
+  test('returns the shop for valid URLs', () => {
+    expect(sanitizeShop(VALID_SHOP_URL_1)).toEqual(VALID_SHOP_URL_1);
+    expect(sanitizeShop(VALID_SHOP_URL_2)).toEqual(VALID_SHOP_URL_2);
+    expect(sanitizeShop(VALID_SHOP_URL_3)).toEqual(VALID_SHOP_URL_3);
+    expect(sanitizeShop(VALID_SHOP_URL_4)).toEqual(VALID_SHOP_URL_4);
+  });
+
+  test('returns null for invalid URLs', () => {
+    expect(sanitizeShop(INVALID_SHOP_URL_1)).toBe(null);
+    expect(sanitizeShop(INVALID_SHOP_URL_2)).toBe(null);
+  });
+
+  test('throws for invalid URLs if set to', () => {
+    expect(() => sanitizeShop(INVALID_SHOP_URL_1, true)).toThrowError(
+      InvalidShopError,
+    );
+    expect(() => sanitizeShop(INVALID_SHOP_URL_2, true)).toThrowError(
+      InvalidShopError,
+    );
+  });
+
+  test('returns the right values when using custom domains', () => {
+    Context.CUSTOM_SHOP_DOMAINS = [CUSTOM_DOMAIN, CUSTOM_DOMAIN_REGEX];
+
+    expect(sanitizeShop(VALID_SHOP_WITH_CUSTOM_DOMAIN)).toEqual(
+      VALID_SHOP_WITH_CUSTOM_DOMAIN,
+    );
+    expect(sanitizeShop(INVALID_SHOP_WITH_CUSTOM_DOMAIN)).toBe(null);
+
+    expect(sanitizeShop(VALID_SHOP_WITH_CUSTOM_DOMAIN_REGEX)).toEqual(
+      VALID_SHOP_WITH_CUSTOM_DOMAIN_REGEX,
+    );
+    expect(sanitizeShop(INVALID_SHOP_WITH_CUSTOM_DOMAIN_REGEX)).toBe(null);
+  });
 });
 
-test("returns false for invalid shop urls, even if they contain the string 'myshopify.io'", () => {
-  const shopUrl = 'notshopify.myshopify.io.org/potato';
-  expect(validateShop(shopUrl)).toBe(false);
+describe('sanitizeHost', () => {
+  test('returns the shop for valid URLs', () => {
+    expect(sanitizeHost(VALID_HOST_1)).toEqual(VALID_HOST_1);
+    expect(sanitizeHost(VALID_HOST_2)).toEqual(VALID_HOST_2);
+  });
+
+  test('returns null for invalid URLs', () => {
+    expect(sanitizeHost(INVALID_HOST_1)).toBe(null);
+    expect(sanitizeHost(INVALID_HOST_2)).toBe(null);
+  });
 });

--- a/src/utils/delete-offline-session.ts
+++ b/src/utils/delete-offline-session.ts
@@ -1,6 +1,8 @@
 import {Context} from '../context';
 import OAuth from '../auth/oauth';
 
+import {sanitizeShop} from './shop-validator';
+
 /**
  * Helper method to find and delete offline sessions by shop url.
  *
@@ -10,6 +12,7 @@ export default async function deleteOfflineSession(
   shop: string,
 ): Promise<boolean> {
   Context.throwIfUninitialized();
+  sanitizeShop(shop, true);
 
   const sessionId = OAuth.getOfflineSessionId(shop);
 

--- a/src/utils/delete-offline-session.ts
+++ b/src/utils/delete-offline-session.ts
@@ -12,9 +12,9 @@ export default async function deleteOfflineSession(
   shop: string,
 ): Promise<boolean> {
   Context.throwIfUninitialized();
-  sanitizeShop(shop, true);
+  const cleanShop = sanitizeShop(shop, true)!;
 
-  const sessionId = OAuth.getOfflineSessionId(shop);
+  const sessionId = OAuth.getOfflineSessionId(cleanShop);
 
   return Context.SESSION_STORAGE.deleteSession(sessionId);
 }

--- a/src/utils/get-embedded-app-url.ts
+++ b/src/utils/get-embedded-app-url.ts
@@ -3,6 +3,8 @@ import http from 'http';
 import * as ShopifyErrors from '../error';
 import {Context} from '../context';
 
+import {sanitizeHost} from './shop-validator';
+
 /**
  * Helper method to get the host URL for the app.
  *
@@ -26,7 +28,7 @@ export default function getEmbeddedAppUrl(
   const url = new URL(request.url, `https://${request.headers.host}`);
   const host = url.searchParams.get('host');
 
-  if (typeof host !== 'string') {
+  if (typeof host !== 'string' || !sanitizeHost(host)) {
     throw new ShopifyErrors.InvalidRequestError(
       'Request does not contain a host query parameter',
     );

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,7 +8,7 @@ import graphqlProxy from './graphql_proxy';
 import safeCompare from './safe-compare';
 import storeSession from './store-session';
 import validateHmac from './hmac-validator';
-import validateShop, {sanitizeShop, sanitizeHost} from './shop-validator';
+import {sanitizeShop, sanitizeHost} from './shop-validator';
 import versionCompatible from './version-compatible';
 import withSession from './with-session';
 import getEmbeddedAppUrl from './get-embedded-app-url';
@@ -24,7 +24,6 @@ const ShopifyUtils = {
   safeCompare,
   storeSession,
   validateHmac,
-  validateShop,
   sanitizeShop,
   sanitizeHost,
   versionCompatible,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,7 +8,7 @@ import graphqlProxy from './graphql_proxy';
 import safeCompare from './safe-compare';
 import storeSession from './store-session';
 import validateHmac from './hmac-validator';
-import validateShop from './shop-validator';
+import validateShop, {sanitizeShop, sanitizeHost} from './shop-validator';
 import versionCompatible from './version-compatible';
 import withSession from './with-session';
 import getEmbeddedAppUrl from './get-embedded-app-url';
@@ -25,6 +25,8 @@ const ShopifyUtils = {
   storeSession,
   validateHmac,
   validateShop,
+  sanitizeShop,
+  sanitizeHost,
   versionCompatible,
   withSession,
   getEmbeddedAppUrl,

--- a/src/utils/load-offline-session.ts
+++ b/src/utils/load-offline-session.ts
@@ -17,9 +17,9 @@ export default async function loadOfflineSession(
   includeExpired = false,
 ): Promise<Session | undefined> {
   Context.throwIfUninitialized();
-  sanitizeShop(shop, true);
+  const cleanShop = sanitizeShop(shop, true)!;
 
-  const sessionId = OAuth.getOfflineSessionId(shop);
+  const sessionId = OAuth.getOfflineSessionId(cleanShop);
   const session = await Context.SESSION_STORAGE.loadSession(sessionId);
 
   const now = new Date();

--- a/src/utils/load-offline-session.ts
+++ b/src/utils/load-offline-session.ts
@@ -2,6 +2,8 @@ import {Session} from '../auth/session/session';
 import {Context} from '../context';
 import OAuth from '../auth/oauth';
 
+import {sanitizeShop} from './shop-validator';
+
 /**
  * Helper method for quickly loading offline sessions by shop url.
  * By default, returns undefined if there is no session, or the session found is expired.
@@ -15,6 +17,7 @@ export default async function loadOfflineSession(
   includeExpired = false,
 ): Promise<Session | undefined> {
   Context.throwIfUninitialized();
+  sanitizeShop(shop, true);
 
   const sessionId = OAuth.getOfflineSessionId(shop);
   const session = await Context.SESSION_STORAGE.loadSession(sessionId);

--- a/src/utils/setup-jest.ts
+++ b/src/utils/setup-jest.ts
@@ -19,6 +19,7 @@ beforeEach(() => {
     IS_EMBEDDED_APP: false,
     IS_PRIVATE_APP: false,
     SESSION_STORAGE: new MemorySessionStorage(),
+    CUSTOM_SHOP_DOMAINS: undefined,
   });
 
   fetchMock.mockReset();

--- a/src/utils/shop-validator.ts
+++ b/src/utils/shop-validator.ts
@@ -2,19 +2,6 @@ import {InvalidHostError, InvalidShopError} from '../error';
 import {Context} from '../context';
 
 /**
- * Validates myshopify.com urls
- *
- * @param shop Shop url: {shop}.myshopify.com
- */
-export default function validateShop(shop: string): boolean {
-  console.warn(
-    'Deprecation notice: validateShop will be removed in the next major release.',
-  );
-  const shopUrlRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]*\.myshopify\.(com|io)[/]*$/;
-  return shopUrlRegex.test(shop);
-}
-
-/**
  * Validates and sanitizes shop domain urls. If Context.CUSTOM_SHOP_DOMAINS is set, shops ending in those domains are
  * allowed. Accepts myshopify.com and myshopify.io by default.
  *

--- a/src/utils/shop-validator.ts
+++ b/src/utils/shop-validator.ts
@@ -35,7 +35,7 @@ export function sanitizeShop(
   }
 
   const shopUrlRegex = new RegExp(
-    `^[a-zA-Z0-9][a-zA-Z0-9-]*\\.(${domainsRegex.join('|')})[/]*$`,
+    `^[a-zA-Z0-9][a-zA-Z0-9-_]*\\.(${domainsRegex.join('|')})[/]*$`,
   );
 
   const sanitizedShop = shopUrlRegex.test(shop) ? shop : null;

--- a/src/utils/shop-validator.ts
+++ b/src/utils/shop-validator.ts
@@ -1,3 +1,6 @@
+import {InvalidHostError, InvalidShopError} from '../error';
+import {Context} from '../context';
+
 /**
  * Validates myshopify.com urls
  *
@@ -9,4 +12,57 @@ export default function validateShop(shop: string): boolean {
   );
   const shopUrlRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]*\.myshopify\.(com|io)[/]*$/;
   return shopUrlRegex.test(shop);
+}
+
+/**
+ * Validates and sanitizes shop domain urls. If Context.CUSTOM_SHOP_DOMAINS is set, shops ending in those domains are
+ * allowed. Accepts myshopify.com and myshopify.io by default.
+ *
+ * @param shop Shop url: {shop}.{domain}
+ * @param throwOnInvalid Whether to raise an exception if the shop is invalid
+ */
+export function sanitizeShop(
+  shop: string,
+  throwOnInvalid = false,
+): string | null {
+  const domainsRegex = ['myshopify\\.com', 'myshopify\\.io'];
+  if (Context.CUSTOM_SHOP_DOMAINS) {
+    domainsRegex.push(
+      ...Context.CUSTOM_SHOP_DOMAINS.map((regex) =>
+        typeof regex === 'string' ? regex : regex.source,
+      ),
+    );
+  }
+
+  const shopUrlRegex = new RegExp(
+    `^[a-zA-Z0-9][a-zA-Z0-9-]*\\.(${domainsRegex.join('|')})[/]*$`,
+  );
+
+  const sanitizedShop = shopUrlRegex.test(shop) ? shop : null;
+  if (!sanitizedShop && throwOnInvalid) {
+    throw new InvalidShopError('Received invalid shop argument');
+  }
+
+  return sanitizedShop;
+}
+
+/**
+ * Validates and sanitizes Shopify host arguments.
+ *
+ * @param host Host address
+ * @param throwOnInvalid Whether to raise an exception if the host is invalid
+ */
+export function sanitizeHost(
+  host: string,
+  throwOnInvalid = false,
+): string | null {
+  const base64regex =
+    /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
+
+  const sanitizedHost = base64regex.test(host) ? host : null;
+  if (!sanitizedHost && throwOnInvalid) {
+    throw new InvalidHostError('Received invalid host argument');
+  }
+
+  return sanitizedHost;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

When receiving user input data, apps should be able to easily validate that they are in the expected format / safe.

### WHAT is this pull request doing?

Adding Utils methods `sanitizeShop` and `sanitizeHost` to make it easier for apps to validate / fail requests on a single call.

I ended up opting not to reuse `validateShop` because I like the ergonomics of 

```ts
try {
  const shop = Shopify.Utils.sanitizeShop(req.query.shop, true); // Second arg is throwOnInvalid
} catch (e) {
  // Custom error handling
}

// or even no try-catch to just bork since it's a bad request anyway
const shop = Shopify.Utils.sanitizeShop(req.query.shop, true);
```

better than

```ts
const shop = req.query.shop;
if (!Shopify.Utils.validateShop()) {
  throw new Error("this message will be repeated quite a few times");
}
```

## Type of change

- [x] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
