### PR TITLE
Pass in User-Agent header in PUT / POST requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - ⚠️ [Breaking] If a response from a GraphQL query contains an `errors` attribute, `GraphqlClient` will now throw a `GraphqlQueryError`. The caller can check the `error.response` attribute to see what was returned from the GraphQL API. [#431](https://github.com/Shopify/shopify-api-node/pull/431)
 - ⚠️ [Breaking] Add utils functions to sanitize shops and hosts, and remove the `validateShop` utils function [#434](https://github.com/Shopify/shopify-api-node/pull/434)
 - Allow passing in options for the Redis client used by the session storage strategy [#430](https://github.com/Shopify/shopify-api-node/pull/430)
+- Fix User-Agent header sent in PUT / POST requests [#435](https://github.com/Shopify/shopify-api-node/pull/435)
 
 ## [4.2.0] - 2022-07-20
 

--- a/src/clients/http_client/__tests__/http_client.test.ts
+++ b/src/clients/http_client/__tests__/http_client.test.ts
@@ -29,7 +29,14 @@ describe('HTTP client', () => {
     await expect(client.get({path: '/url/path'})).resolves.toEqual(
       buildExpectedResponse(successResponse),
     );
-    expect({method: 'GET', domain, path: '/url/path'}).toMatchMadeHttpRequest();
+    expect({
+      method: 'GET',
+      domain,
+      path: '/url/path',
+      headers: {
+        'User-Agent': expect.stringContaining('Shopify API Library v'),
+      },
+    }).toMatchMadeHttpRequest();
   });
 
   it('allows the body to contain non-json 2xx response without dying', () => {
@@ -78,7 +85,11 @@ describe('HTTP client', () => {
       method: 'POST',
       domain,
       path: '/url/path',
-      headers: {'Content-Type': DataType.JSON.toString()},
+      headers: {
+        'Content-Length': JSON.stringify(postData).length,
+        'Content-Type': DataType.JSON.toString(),
+        'User-Agent': expect.stringContaining('Shopify API Library v'),
+      },
       data: JSON.stringify(postData),
     }).toMatchMadeHttpRequest();
   });
@@ -247,7 +258,11 @@ describe('HTTP client', () => {
       method: 'PUT',
       domain,
       path: '/url/path/123',
-      headers: {'Content-Type': DataType.JSON.toString()},
+      headers: {
+        'Content-Length': JSON.stringify(putData).length,
+        'Content-Type': DataType.JSON.toString(),
+        'User-Agent': expect.stringContaining('Shopify API Library v'),
+      },
       data: JSON.stringify(putData),
     }).toMatchMadeHttpRequest();
   });
@@ -264,6 +279,9 @@ describe('HTTP client', () => {
       method: 'DELETE',
       domain,
       path: '/url/path/123',
+      headers: {
+        'User-Agent': expect.stringContaining('Shopify API Library v'),
+      },
     }).toMatchMadeHttpRequest();
   });
 

--- a/src/clients/http_client/http_client.ts
+++ b/src/clients/http_client/http_client.ts
@@ -111,9 +111,9 @@ export class HttpClient {
             break;
         }
         headers = {
+          ...headers,
           'Content-Type': type,
           'Content-Length': Buffer.byteLength(body as string),
-          ...params.extraHeaders,
         };
       }
     }


### PR DESCRIPTION
### WHY are these changes introduced?

When sending PUT / POST requests, we were overwriting all of the headers to add the `Content-*` ones, instead of extending what was set before. That meant that we were dropping the `User-Agent` header we set before.

### WHAT is this pull request doing?

Extending the right object after setting the PUT/POST-specific headers.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
