### PR TITLE
Add isomorphic interfaces for HTTP and cryptography features

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,19 +2,26 @@ on: [push, pull_request]
 name: CI
 jobs:
   CI:
+    name: CI (${{ matrix.version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [14, 16, 18]
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: ${{ matrix.version }}
       - name: Install
         run: yarn install
       - name: Lint
         run: yarn lint
       - name: Test
         run: yarn test
-      - name: Test REST resources
-        run: yarn test_rest_resources
+      # TODO reinstate these tests once we re-introduce the wrappers
+      # - name: Test REST resources
+      #   run: yarn test:rest:resources
       - name: Test SessionStorage implementations
-        run: yarn test_sessionstorage
+        run: yarn test:session:storage
+      - name: Run isomorphic tests
+        run: yarn test:adapters:node

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,5 +11,5 @@ module.exports = {
   testRegex: '.*\\.test\\.tsx?$',
   coverageDirectory: './coverage/',
   collectCoverage: true,
-  setupFilesAfterEnv: ['<rootDir>/src/utils/setup-jest.ts'],
+  setupFilesAfterEnv: ['<rootDir>/src/setup-jest.ts'],
 };

--- a/package.json
+++ b/package.json
@@ -6,14 +6,16 @@
     ".": "./dist/src/index.js",
     "./oauth": "./dist/src/auth/oauth/index.js",
     "./webhooks": "./dist/src/webhooks/registry.js",
-    "./runtimes/node": "./dist/src/runtimes/node.js"
+    "./adapters/node": "./dist/src/adapters/node/index.js",
+    "./adapters/cf-worker": "./dist/src/adapters/cf-worker/index.js"
   },
   "types": "dist/index.d.ts",
   "prettier": "@shopify/prettier-config",
   "scripts": {
-    "test": "jest --testPathIgnorePatterns=src/rest-resources/__tests__ --testPathIgnorePatterns=src/auth/session/storage",
-    "test_sessionstorage": "jest src/auth/session/storage",
-    "test_rest_resources": "ls src/rest-resources/__tests__ | xargs -I \"{}\" sh -c 'yarn jest --no-coverage --testPathPattern=\\\"{}\\\" || exit 255'",
+    "test": "jest --testPathIgnorePatterns=src/rest-resources/__tests__ --testPathIgnorePatterns=src/auth/session/storage --testPathIgnorePatterns=src/adapters --testPathIgnorePatterns=src/runtime",
+    "test:adapters:node": "jest src/adapters/node --no-coverage",
+    "test:session:storage": "jest src/auth/session/storage --no-coverage",
+    "test:rest:resources": "ls src/rest-resources/__tests__ | xargs -I \"{}\" sh -c 'yarn jest --no-coverage --testPathPattern=\\\"{}\\\" || exit 255'",
     "build": "tsc",
     "lint": "eslint '**/*.{ts,tsx}' --max-warnings 0",
     "clean": "rimraf ./dist tsconfig.tsbuildinfo",

--- a/src/adapters/cf-worker/adapter.ts
+++ b/src/adapters/cf-worker/adapter.ts
@@ -1,0 +1,50 @@
+import {
+  canonicalizeHeaders,
+  flatHeaders,
+  AdapterArgs,
+  NormalizedRequest,
+  NormalizedResponse,
+} from '../../runtime/http';
+
+interface WorkerAdapterArgs extends AdapterArgs {
+  rawRequest: Request;
+}
+
+export async function workerConvertRequest(
+  adapterArgs: WorkerAdapterArgs,
+): Promise<NormalizedRequest> {
+  const req = adapterArgs.rawRequest;
+  const body = await req.text();
+  return {
+    headers: canonicalizeHeaders(req.headers as any),
+    method: req.method ?? 'GET',
+    url: req.url!,
+    body,
+  };
+}
+
+export async function workerConvertResponse(
+  resp: NormalizedResponse,
+): Promise<Response> {
+  return new Response(resp.body, {
+    status: resp.statusCode,
+    statusText: resp.statusText,
+    headers: flatHeaders(resp.headers ?? {}),
+  });
+}
+
+export async function workerFetch({
+  url,
+  method,
+  headers = {},
+  body,
+}: NormalizedRequest): Promise<NormalizedResponse> {
+  const resp = await fetch(url, {method, headers: flatHeaders(headers), body});
+  const respBody = await resp.text();
+  return {
+    statusCode: resp.status,
+    statusText: resp.statusText,
+    body: respBody,
+    headers: canonicalizeHeaders(Object.fromEntries(resp.headers.entries())),
+  };
+}

--- a/src/adapters/cf-worker/index.ts
+++ b/src/adapters/cf-worker/index.ts
@@ -1,0 +1,17 @@
+import {
+  setAbstractFetchFunc,
+  setAbstractConvertRequestFunc,
+  setAbstractConvertResponseFunc,
+} from '../../runtime/http';
+import {setCrypto} from '../../runtime/crypto';
+
+import {
+  workerFetch,
+  workerConvertRequest,
+  workerConvertResponse,
+} from './adapter';
+
+setAbstractFetchFunc(workerFetch);
+setAbstractConvertRequestFunc(workerConvertRequest);
+setAbstractConvertResponseFunc(workerConvertResponse);
+setCrypto(crypto as any);

--- a/src/adapters/node/__tests__/node.test.ts
+++ b/src/adapters/node/__tests__/node.test.ts
@@ -1,0 +1,3 @@
+import '..';
+
+import '../../../runtime/__tests__/all.test';

--- a/src/adapters/node/adapter.ts
+++ b/src/adapters/node/adapter.ts
@@ -1,0 +1,73 @@
+import type {IncomingMessage, ServerResponse} from 'http';
+
+import fetch from 'node-fetch';
+
+import {
+  AdapterArgs,
+  canonicalizeHeaders,
+  flatHeaders,
+  NormalizedRequest,
+  NormalizedResponse,
+} from '../../runtime/http';
+
+interface NodeAdapterArgs extends AdapterArgs {
+  rawRequest: IncomingMessage;
+  rawResponse: ServerResponse;
+}
+
+export async function nodeConvertRequest(
+  adapterArgs: NodeAdapterArgs,
+): Promise<NormalizedRequest> {
+  const req = adapterArgs.rawRequest;
+  const body = await new Promise<string>((resolve, reject) => {
+    let str = '';
+    req.on('data', (chunk) => {
+      str += chunk.toString();
+    });
+    req.on('error', (error) => reject(error));
+    req.on('end', () => resolve(str));
+  });
+  return {
+    headers: canonicalizeHeaders({...req.headers} as any),
+    method: req.method ?? 'GET',
+    url: req.url!,
+    body,
+  };
+}
+
+export async function nodeConvertAndSendResponse(
+  response: NormalizedResponse,
+  adapterArgs: NodeAdapterArgs,
+): Promise<void> {
+  const res = adapterArgs.rawResponse;
+  res.statusCode = response.statusCode;
+  res.statusMessage = response.statusText;
+
+  if (response.headers) {
+    Object.entries(response.headers).forEach(([header, value]) =>
+      res.setHeader(header, value),
+    );
+  }
+
+  if (response.body) {
+    res.write(response.body);
+  }
+
+  res.end();
+}
+
+export async function nodeFetch({
+  url,
+  method,
+  headers = {},
+  body,
+}: NormalizedRequest): Promise<NormalizedResponse> {
+  const resp = await fetch(url, {method, headers: flatHeaders(headers), body});
+  const respBody = await resp.text();
+  return {
+    statusCode: resp.status,
+    statusText: resp.statusText,
+    body: respBody,
+    headers: canonicalizeHeaders(Object.fromEntries(resp.headers.entries())),
+  };
+}

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -1,0 +1,19 @@
+import crypto from 'crypto';
+
+import {
+  setAbstractFetchFunc,
+  setAbstractConvertRequestFunc,
+  setAbstractConvertResponseFunc,
+} from '../../runtime/http';
+import {setCrypto} from '../../runtime/crypto';
+
+import {
+  nodeFetch,
+  nodeConvertRequest,
+  nodeConvertAndSendResponse,
+} from './adapter';
+
+setAbstractFetchFunc(nodeFetch);
+setAbstractConvertRequestFunc(nodeConvertRequest);
+setAbstractConvertResponseFunc(nodeConvertAndSendResponse);
+setCrypto(crypto as any);

--- a/src/runtime/__tests__/all.test.ts
+++ b/src/runtime/__tests__/all.test.ts
@@ -1,0 +1,2 @@
+import '../crypto/__tests__/hmac.test';
+import '../http/__tests__/http.test';

--- a/src/runtime/crypto/__tests__/hmac.test.ts
+++ b/src/runtime/crypto/__tests__/hmac.test.ts
@@ -1,0 +1,43 @@
+import {crypto} from '../crypto';
+import {createSHA256HMAC, asBase64} from '..';
+
+const NUM_FUZZS = 100;
+describe('Wrapper to create HMACs', () => {
+  it('gives the same results as Node’s crypto API', async () => {
+    for (let i = 0; i < NUM_FUZZS; i++) {
+      const secret = (crypto as any)
+        .randomBytes(random({min: 4, max: 32}))
+        .toString('hex');
+      const payload = (crypto as any)
+        .randomBytes(random({min: 4, max: 128}))
+        .toString('hex');
+      const hmac = await createSHA256HMAC(secret, payload);
+      const nodeHmac = (crypto as any)
+        .createHmac('sha256', secret)
+        .update(payload, 'utf8')
+        .digest('base64');
+
+      expect(hmac).toEqual(nodeHmac);
+    }
+  });
+});
+
+describe('Base64 encoder', () => {
+  it('gives the same results as Node', async () => {
+    for (let i = 0; i < NUM_FUZZS; i++) {
+      const payload = (crypto as any).randomBytes(random({min: 4, max: 128}));
+      const b64Encoding = asBase64(payload.buffer);
+      const b64EncodingNode = payload.toString('base64');
+
+      expect(b64Encoding).toEqual(b64EncodingNode);
+    }
+  });
+});
+
+function random({min = 0, max = 1, floor = true} = {}): number {
+  let value = Math.random() * (max - min) + min;
+  if (floor) {
+    value = Math.floor(value);
+  }
+  return value;
+}

--- a/src/runtime/crypto/crypto.ts
+++ b/src/runtime/crypto/crypto.ts
@@ -1,0 +1,7 @@
+// The mutable export is the whole key to the adapter architecture.
+
+// eslint-disable-next-line import/no-mutable-exports
+export let crypto: Crypto;
+export function setCrypto(providedCrypto: Crypto) {
+  crypto = providedCrypto;
+}

--- a/src/runtime/crypto/index.ts
+++ b/src/runtime/crypto/index.ts
@@ -1,0 +1,2 @@
+export * from './crypto';
+export * from './utils';

--- a/src/runtime/crypto/utils.ts
+++ b/src/runtime/crypto/utils.ts
@@ -1,0 +1,81 @@
+import {crypto} from './crypto';
+
+export async function createSHA256HMAC(
+  secret: string,
+  payload: string,
+): Promise<string> {
+  const webcrypto = (crypto as any).webcrypto;
+
+  if (webcrypto?.subtle) {
+    const enc = new TextEncoder();
+    const key = await webcrypto.subtle.importKey(
+      'raw',
+      enc.encode(secret),
+      {
+        name: 'HMAC',
+        hash: {name: 'SHA-256'},
+      },
+      false,
+      ['sign'],
+    );
+
+    const signature = await webcrypto.subtle.sign(
+      'HMAC',
+      key,
+      enc.encode(payload),
+    );
+    return asBase64(signature);
+  } else {
+    return (crypto as any)
+      .createHmac('sha256', secret)
+      .update(payload)
+      .digest('base64');
+  }
+}
+
+export function asHex(buffer: ArrayBuffer): string {
+  return [...new Uint8Array(buffer)]
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+const LookupTable =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+export function asBase64(buffer: ArrayBuffer): string {
+  let output = '';
+
+  const input = new Uint8Array(buffer);
+  for (let i = 0; i < input.length; ) {
+    const byte1 = input[i++];
+    const byte2 = input[i++];
+    const byte3 = input[i++];
+
+    const enc1 = byte1 >> 2;
+    const enc2 = ((byte1 & 0b00000011) << 4) | (byte2 >> 4);
+    let enc3 = ((byte2 & 0b00001111) << 2) | (byte3 >> 6);
+    let enc4 = byte3 & 0b00111111;
+
+    if (isNaN(byte2)) {
+      enc3 = 64;
+    }
+    if (isNaN(byte3)) {
+      enc4 = 64;
+    }
+
+    output +=
+      LookupTable[enc1] +
+      LookupTable[enc2] +
+      LookupTable[enc3] +
+      LookupTable[enc4];
+  }
+  return output;
+}
+
+export async function hashStringWithSHA256(input: string): Promise<string> {
+  const buffer = new TextEncoder().encode(input);
+  const hash = await (crypto as any).webcrypto.subtle.digest(
+    {name: 'SHA-256'},
+    buffer,
+  );
+  return asHex(hash);
+}

--- a/src/runtime/http/__tests__/http.test.ts
+++ b/src/runtime/http/__tests__/http.test.ts
@@ -1,0 +1,146 @@
+import {crypto} from '../../crypto';
+import {
+  addHeader,
+  canonicalizeHeaderName,
+  canonicalizeHeaders,
+  Cookies,
+  getHeaders,
+  Headers,
+  removeHeader,
+  NormalizedRequest,
+  NormalizedResponse,
+  setHeader,
+} from '..';
+
+describe('Cookies', () => {
+  let req: NormalizedRequest;
+  let res: NormalizedResponse;
+  beforeEach(() => {
+    req = {
+      method: 'GET',
+      url: '/',
+      headers: {
+        Cookie: 'session=123',
+      },
+    };
+    res = {
+      statusCode: 200,
+      statusText: 'OK',
+    };
+  });
+
+  it('parses Cookies in the NormalizedRequest', async () => {
+    const cookieJar = new Cookies(req, res);
+    expect(cookieJar.get('session')).toEqual('123');
+  });
+
+  it('generates cookie header', async () => {
+    const cookieJar = new Cookies(req, res);
+    cookieJar.set('new_session', 'lol');
+    expect(
+      getHeaders(res.headers, 'Set-Cookie').some((cookieHdr) =>
+        cookieHdr.includes('new_session=lol'),
+      ),
+    ).toBeTruthy();
+  });
+
+  it('can set multiple cookies', async () => {
+    const cookieJar = new Cookies(req, res);
+    cookieJar.set('new_session', 'lol');
+    cookieJar.set('other_session', 'lol');
+    expect(getHeaders(res.headers, 'Set-Cookie').length).toEqual(2);
+  });
+
+  it('can sign cookies', async () => {
+    const keys = [crypto.randomUUID()];
+    const cookieJar = new Cookies(req, res, {keys});
+    await cookieJar.setAndSign('new_session', 'lol');
+    expect(getHeaders(res.headers, 'Set-Cookie').length).toEqual(2);
+  });
+});
+
+describe('Header operations', () => {
+  let headers: Headers;
+  beforeEach(() => {
+    headers = {};
+  });
+
+  it('can canonicalize a header name', async () => {
+    expect(canonicalizeHeaderName('x-my-header')).toEqual('X-My-Header');
+    expect(canonicalizeHeaderName('x-my-hEader')).toEqual('X-My-Header');
+  });
+
+  it('can get a header from a non-canon header object', async () => {
+    headers = {
+      'x-my-header': 'a',
+    };
+    expect(getHeaders(headers, 'X-My-Header')).toEqual(['a']);
+  });
+
+  it('can accumulate headers from a non-canon header object', async () => {
+    headers = {
+      'X-My-Header': 'a',
+      'x-my-header': ['b', 'c'],
+      'x-My-header': 'd',
+    };
+    expect(getHeaders(headers, 'X-My-Header')).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('can overwrite headers', async () => {
+    setHeader(headers, 'X-My-Header', 'a');
+    setHeader(headers, 'X-My-Header', 'b');
+    expect(getHeaders(headers, 'X-My-Header')).toEqual(['b']);
+  });
+
+  it('can overwrite headers with mismatching case', async () => {
+    setHeader(headers, 'X-My-Header', 'a');
+    setHeader(headers, 'x-my-header', 'b');
+    expect(getHeaders(headers, 'X-My-Header')).toEqual(['b']);
+  });
+
+  it('can add headers', async () => {
+    addHeader(headers, 'X-My-Header', 'a');
+    expect(getHeaders(headers, 'X-My-Header')).toEqual(['a']);
+  });
+
+  it('can add multiple headers', async () => {
+    addHeader(headers, 'X-My-Header', 'a');
+    addHeader(headers, 'X-My-Header', 'b');
+    expect(getHeaders(headers, 'X-My-Header')).toEqual(['a', 'b']);
+  });
+
+  it('can delete headers', async () => {
+    addHeader(headers, 'X-My-Header', 'a');
+    addHeader(headers, 'X-My-Header', 'b');
+    removeHeader(headers, 'X-My-Header');
+    addHeader(headers, 'X-My-Header', 'c');
+    expect(getHeaders(headers, 'X-My-Header')).toEqual(['c']);
+  });
+
+  it('can canonicalize a header object', async () => {
+    headers = {
+      'x-My-header': 'a',
+      'x-my-header': ['b', 'c'],
+      'X-My-Header': 'd',
+      'x-my-hEader': 'e',
+      'other-header': 4 as any,
+      'other-heaDer': 5 as any,
+      'yet-another-header': [3, 5] as any,
+    };
+    canonicalizeHeaders(headers);
+
+    expect(Object.keys(headers)).toHaveLength(3);
+
+    ['a', 'b', 'c', 'd', 'e'].forEach((letter) =>
+      expect(headers['X-My-Header']).toContain(letter),
+    );
+    expect(headers['X-My-Header']).toHaveLength(5);
+
+    expect(headers['Yet-Another-Header']).toEqual(['3', '5']);
+    ['4', '5'].forEach((letter) =>
+      expect(headers['Other-Header']).toContain(letter),
+    );
+
+    expect(headers['Other-Header']).toHaveLength(2);
+  });
+});

--- a/src/runtime/http/cookies.ts
+++ b/src/runtime/http/cookies.ts
@@ -1,0 +1,201 @@
+// import type {Headers} from "./headers";
+import {createSHA256HMAC} from '../crypto/utils';
+
+import {splitN} from './utils';
+import {getHeader, getHeaders, removeHeader, addHeader} from './headers';
+
+import type {NormalizedRequest, NormalizedResponse} from '.';
+
+export interface CookieData {
+  name: string;
+  value: string;
+  /**
+   * a number representing the milliseconds from Date.now() for expiry
+   */
+  maxAge?: number;
+  /**
+   * a Date object indicating the cookie's expiration
+   * date (expires at the end of session by default).
+   */
+  expires?: Date;
+  /**
+   * a string indicating the path of the cookie (/ by default).
+   */
+  path?: string;
+  /**
+   * a string indicating the domain of the cookie (no default).
+   */
+  domain?: string;
+  /**
+   * a boolean indicating whether the cookie is only to be sent
+   * over HTTPS (false by default for HTTP, true by default for HTTPS).
+   */
+  secure?: boolean;
+  /**
+   * a boolean indicating whether the cookie is only to be sent over HTTP(S),
+   * and not made available to client JavaScript (true by default).
+   */
+  httpOnly?: boolean;
+  /**
+   * a boolean or string indicating whether the cookie is a "same site" cookie (false by default).
+   * This can be set to 'strict', 'lax', or true (which maps to 'strict').
+   */
+  sameSite?: 'strict' | 'lax' | 'none';
+}
+
+export interface CookieJar {
+  [key: string]: CookieData;
+}
+interface CookiesOptions {
+  keys: string[];
+  // Ignored. Only for type-compatibility with the node package for now.
+  secure: boolean;
+}
+export class Cookies {
+  static parseCookies(hdrs: string[]): CookieJar {
+    const entries = hdrs
+      .filter((hdr) => hdr.trim().length > 0)
+      .map((cookieDef) => {
+        const [keyval, ...opts] = cookieDef.split(';');
+        const [name, value] = splitN(keyval, '=', 2).map((value) =>
+          value.trim(),
+        );
+        return [
+          name,
+          {
+            name,
+            value,
+            ...Object.fromEntries(
+              opts.map((opt) =>
+                splitN(opt, '=', 2).map((value) => value.trim()),
+              ),
+            ),
+          },
+        ];
+      });
+    const jar = Object.fromEntries(entries) as CookieJar;
+    for (const cookie of Object.values(jar)) {
+      if (typeof cookie.expires === 'string') {
+        cookie.expires = new Date(cookie.expires);
+      }
+    }
+    return jar;
+  }
+
+  static encodeCookie(data: CookieData): string {
+    let result = '';
+    result += `${data.name}=${data.value};`;
+    result += Object.entries(data)
+      .filter(([key]) => !['name', 'value', 'expires'].includes(key))
+      .map(([key, value]) => `${key}=${value}`)
+      .join('; ');
+    if (data.expires) {
+      result += ';';
+      result += `expires=${data.expires.toUTCString()}`;
+    }
+    return result;
+  }
+
+  receivedCookieJar: CookieJar = {};
+  outgoingCookieJar: CookieJar = {};
+  private keys: string[] = [];
+
+  constructor(
+    req: NormalizedRequest,
+    public response: NormalizedResponse,
+    {keys = []}: Partial<CookiesOptions> = {},
+  ) {
+    if (keys) this.keys = keys;
+
+    const cookieReqHdr = getHeader(req.headers, 'Cookie') ?? '';
+    this.receivedCookieJar = Cookies.parseCookies(cookieReqHdr.split(','));
+    const cookieResHdr = getHeaders(response.headers, 'Set-Cookie') ?? [];
+    this.outgoingCookieJar = Cookies.parseCookies(cookieResHdr);
+  }
+
+  toHeaders(): string[] {
+    return Object.values(this.outgoingCookieJar).map((cookie) =>
+      Cookies.encodeCookie(cookie),
+    );
+  }
+
+  updateHeader() {
+    if (!this.response.headers) {
+      this.response.headers = {};
+    }
+    removeHeader(this.response.headers, 'Set-Cookie');
+    this.toHeaders().map((hdr) =>
+      addHeader(this.response.headers!, 'Set-Cookie', hdr),
+    );
+  }
+
+  get(name: string): string | undefined {
+    return this.receivedCookieJar[name]?.value;
+  }
+
+  deleteCookie(name: string) {
+    this.set(name, '', {
+      path: '/',
+      expires: new Date(0),
+    });
+  }
+
+  async getAndVerify(name: string): Promise<string | undefined> {
+    const value = this.get(name);
+    if (!value) return undefined;
+    if (!(await this.isSignedCookieValid(name))) {
+      return undefined;
+    }
+    return value;
+  }
+
+  private get canSign() {
+    return this.keys?.length > 0;
+  }
+
+  set(name: string, value: string, opts: Partial<CookieData> = {}): void {
+    this.outgoingCookieJar[name] = {
+      ...opts,
+      name,
+      value,
+    };
+    this.updateHeader();
+  }
+
+  async setAndSign(
+    name: string,
+    value: string,
+    opts: Partial<CookieData> = {},
+  ): Promise<void> {
+    if (!this.canSign) {
+      throw Error('No keys provided for signing.');
+    }
+    this.set(name, value, opts);
+    const sigName = `${name}.sig`;
+    const signature = await createSHA256HMAC(this.keys[0], value);
+    this.set(sigName, signature, opts);
+    this.updateHeader();
+  }
+
+  async isSignedCookieValid(cookieName: string): Promise<boolean> {
+    const signedCookieName = `${cookieName}.sig`;
+    // No cookie or no signature cookie makes the cookie it invalid.
+    if (!this.get(cookieName) || !this.get(signedCookieName)) {
+      this.deleteCookie(signedCookieName);
+      this.deleteCookie(cookieName);
+      return false;
+    }
+
+    const value = this.get(cookieName)!;
+    const signature = this.get(signedCookieName)!;
+    const allCheckSignatures = await Promise.all(
+      this.keys.map((key) => createSHA256HMAC(key, value)),
+    );
+    if (!allCheckSignatures.includes(signature)) {
+      this.deleteCookie(signedCookieName);
+      this.deleteCookie(cookieName);
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/runtime/http/headers.ts
+++ b/src/runtime/http/headers.ts
@@ -1,0 +1,98 @@
+import type {Headers} from './types';
+
+export function canonicalizeHeaderName(hdr: string): string {
+  return hdr.replace(
+    /(^|-)(\w+)/g,
+    (_fullMatch, start, letters) =>
+      start +
+      letters.slice(0, 1).toUpperCase() +
+      letters.slice(1).toLowerCase(),
+  );
+}
+
+export function getHeaders(
+  headers: Headers | undefined,
+  needle_: string,
+): string[] {
+  const result: string[] = [];
+  if (!headers) return result;
+  const needle = canonicalizeHeaderName(needle_);
+  for (const [key, values] of Object.entries(headers)) {
+    if (canonicalizeHeaderName(key) !== needle) continue;
+    if (Array.isArray(values)) {
+      result.push(...values);
+    } else {
+      result.push(values);
+    }
+  }
+  return result;
+}
+
+export function getHeader(
+  headers: Headers | undefined,
+  needle: string,
+): string | undefined {
+  if (!headers) return undefined;
+  return getHeaders(headers, needle)?.[0];
+}
+
+export function setHeader(headers: Headers, key: string, value: string) {
+  canonicalizeHeaders(headers);
+  headers[canonicalizeHeaderName(key)] = [value];
+}
+
+export function addHeader(headers: Headers, key: string, value: string) {
+  canonicalizeHeaders(headers);
+  const canonKey = canonicalizeHeaderName(key);
+  let list = headers[canonKey];
+  if (!list) {
+    list = [];
+  } else if (!Array.isArray(list)) {
+    list = [list];
+  }
+  headers[canonKey] = list;
+  list.push(value);
+}
+
+function canonicalizeValue(value: any): any {
+  if (typeof value === 'number') return value.toString();
+  return value;
+}
+
+export function canonicalizeHeaders(hdr: Headers): Headers {
+  for (const [key, values] of Object.entries(hdr)) {
+    const canonKey = canonicalizeHeaderName(key);
+    if (!hdr[canonKey]) hdr[canonKey] = [];
+    if (!Array.isArray(hdr[canonKey]))
+      hdr[canonKey] = [canonicalizeValue(hdr[canonKey])];
+    if (key === canonKey) continue;
+    delete hdr[key];
+    (hdr[canonKey] as any).push(
+      ...[values].flat().map((value) => canonicalizeValue(value)),
+    );
+  }
+  return hdr;
+}
+
+export function removeHeader(headers: Headers, needle: string) {
+  canonicalizeHeaders(headers);
+  const canonKey = canonicalizeHeaderName(needle);
+  delete headers[canonKey];
+}
+
+/*
+  Turns a Headers object into a array of tuples, as expected by web standards to
+	handle headers that can be specified multiple times.
+  [
+    ["Set-Cookie", "a=b"],
+    ["Set-Cookie", "x=y"],
+    // ...
+  ]
+*/
+export function flatHeaders(headers: Headers): string[][] {
+  return Object.entries(headers).flatMap(([header, values]) =>
+    Array.isArray(values)
+      ? values.map((value) => [header, value])
+      : [[header, values]],
+  );
+}

--- a/src/runtime/http/index.ts
+++ b/src/runtime/http/index.ts
@@ -1,0 +1,53 @@
+import type {
+  AbstractFetchFunc,
+  AbstractConvertRequestFunc,
+  AbstractConvertResponseFunc,
+  NormalizedResponse,
+} from './types';
+
+export * from './cookies';
+export * from './headers';
+export * from './utils';
+
+export * from './types';
+
+export function isOK(resp: NormalizedResponse) {
+  // https://fetch.spec.whatwg.org/#ok-status
+  return resp.statusCode >= 200 && resp.statusCode <= 299;
+}
+
+// We ignore mutable export linting errors because we explicitly want these abstract functions to be overwritten.
+
+// eslint-disable-next-line import/no-mutable-exports
+export let abstractFetch: AbstractFetchFunc = () => {
+  throw new Error(
+    "Missing adapter implementation for 'abstractFetch' - make sure to import the appropriate adapter for your platform",
+  );
+};
+export function setAbstractFetchFunc(func: AbstractFetchFunc) {
+  abstractFetch = func;
+}
+
+// eslint-disable-next-line import/no-mutable-exports
+export let abstractConvertRequest: AbstractConvertRequestFunc = () => {
+  throw new Error(
+    "Missing adapter implementation for 'abstractConvertRequest' - make sure to import the appropriate adapter for your platform",
+  );
+};
+export function setAbstractConvertRequestFunc(
+  func: AbstractConvertRequestFunc,
+) {
+  abstractConvertRequest = func;
+}
+
+// eslint-disable-next-line import/no-mutable-exports
+export let abstractConvertResponse: AbstractConvertResponseFunc = () => {
+  throw new Error(
+    "Missing adapter implementation for 'abstractConvertResponse' - make sure to import the appropriate adapter for your platform",
+  );
+};
+export function setAbstractConvertResponseFunc(
+  func: AbstractConvertResponseFunc,
+) {
+  abstractConvertResponse = func;
+}

--- a/src/runtime/http/types.ts
+++ b/src/runtime/http/types.ts
@@ -1,0 +1,37 @@
+export interface Headers {
+  [key: string]: string | string[];
+}
+
+export interface NormalizedRequest {
+  method: string;
+  url: string;
+  headers: Headers;
+  body?: string;
+}
+
+export interface NormalizedResponse {
+  statusCode: number;
+  statusText: string;
+  headers?: Headers;
+  body?: string;
+}
+
+export type AdapterRequest = any;
+export type AdapterResponse = any;
+export interface AdapterArgs {
+  rawRequest: AdapterRequest;
+  rawResponse?: AdapterResponse;
+}
+
+export type AbstractFetchFunc = (
+  req: NormalizedRequest,
+) => Promise<NormalizedResponse>;
+
+export type AbstractConvertRequestFunc = (
+  adapterArgs: AdapterArgs,
+) => Promise<NormalizedRequest>;
+
+export type AbstractConvertResponseFunc = (
+  response: NormalizedResponse,
+  adapterArgs: AdapterArgs,
+) => Promise<AdapterResponse>;

--- a/src/runtime/http/utils.ts
+++ b/src/runtime/http/utils.ts
@@ -1,0 +1,10 @@
+export function splitN(
+  str: string,
+  sep: string,
+  maxNumParts: number,
+): string[] {
+  const parts = str.split(sep);
+  const maxParts = Math.min(Math.abs(maxNumParts), parts.length);
+
+  return [...parts.slice(0, maxParts - 1), parts.slice(maxParts - 1).join(sep)];
+}

--- a/src/setup-jest.ts
+++ b/src/setup-jest.ts
@@ -1,8 +1,8 @@
 import fetchMock from 'jest-fetch-mock';
 
-import {Context} from '../context';
-import {ApiVersion} from '../base-types';
-import {MemorySessionStorage} from '../auth/session';
+import {Context} from './context';
+import {ApiVersion} from './base-types';
+import {MemorySessionStorage} from './auth/session';
 
 fetchMock.enableMocks();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1068,10 +1068,15 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@^14.18.12":
+"@types/node@*":
   version "14.18.12"
   resolved "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz"
   integrity sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==
+
+"@types/node@^14.18.12":
+  version "14.18.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.23.tgz#70f5f20b0b1b38f696848c1d3647bb95694e615e"
+  integrity sha512-MhbCWN18R4GhO8ewQWAFK4TGQdBpXWByukz7cWyJmXhvRuCIaM/oWytGPqVmDzgEnnaIc9ss6HbU5mUi+vyZPA==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
### WHY are these changes introduced?

The first step towards making this library isomorphic is to define an interface that allows all of the different runtime environments.

### WHAT is this pull request doing?

Porting over the spike interfaces we were using, with a couple of minor tweaks to the public interface exposed by the node runtime.

This makes the following changes to the previous iteration:
- Changed the tests under `runtime` to be executed by being included in a runtime-specific test file (`/src/adapters/node/__tests__`). This way, we can run the runtime tests on any runtimes we support for free, since the interface is generic
- Changed the public interface of the adapter to only export `abstractFetch` to handle internal fetch requests, and `abstractHandleRequest` to handle cases where we need to deal with the incoming requests and send a response

## Checklist

- [x] I have added/updated tests for this change
