### PR TITLE
Fix broken link to billing docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ You can follow our getting started guide, which will provide instructions on how
 - [Webhooks](usage/webhooks.md)
   - [Register a Webhook](usage/webhooks.md#register-a-webhook)
   - [Process a Webhook](usage/webhooks.md#process-a-webhook)
-- [Billing](docs/usage/billing.md)
+- [Billing](usage/billing.md)
 - [Create a `CustomSessionStorage` Solution](usage/customsessions.md)
   - [Usage Example with Redis](usage/customsessions.md#example-usage)
 - [Known issues and caveats](issues.md)


### PR DESCRIPTION
This is just fixing a broken link the docs from the getting started ToC to the billing docs.