### PR TITLE
Increase JWT validation tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- Increased tolerance for expired JWT session tokens from 5s to 10s [#462](https://github.com/Shopify/shopify-api-node/pull/462)
 - Add support for billing to the library [#449](https://github.com/Shopify/shopify-api-node/pull/449)
 - Allow dynamically typing the body of REST and GraphQL request responses, so callers don't need to cast it [#447](https://github.com/Shopify/shopify-api-node/pull/447)
 - Rather than create a temporary session in order to store a session id in a cookie for the OAuth transaction, we can store the `state` in the cookie instead, that can then be compared against the `state` provided by Shopify in the callback. [#438](https://github.com/Shopify/shopify-api-node/pull/438)

--- a/src/utils/decode-session-token.ts
+++ b/src/utils/decode-session-token.ts
@@ -3,7 +3,7 @@ import jwt from 'jsonwebtoken';
 import {Context} from '../context';
 import * as ShopifyErrors from '../error';
 
-const JWT_PERMITTED_CLOCK_TOLERANCE = 5;
+const JWT_PERMITTED_CLOCK_TOLERANCE = 10;
 
 interface JwtPayload {
   iss: string;


### PR DESCRIPTION
### WHY are these changes introduced?

We currently have a 5s grace period for validating JWTs from session token, but there are cases where that is not long enough and we still end up failing to validate the token.

### WHAT is this pull request doing?

Increase the period to 10s which seems to eliminate the problem for good.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
