### PR TITLE
Use abstract default session storage

### DIFF
--- a/docs/issues.md
+++ b/docs/issues.md
@@ -8,9 +8,14 @@ Before you start writing your application, please note that the Shopify library 
 
 `MemorySessionStorage` is **purposely** designed to be a single-process, development-only solution. It **will leak** memory in most cases and delete all sessions when your app restarts. You should **never** use it in production apps.
 
-`SQLiteSessionStorage` (the library default) is designed to be a single-process solution and _may_ be sufficient for your production needs depending on your applications design and needs.
+`SQLiteSessionStorage` is designed to be a single-process solution and _may_ be sufficient for your production needs depending on your applications design and needs.
 
-The other storage adapters (`MongoDBSessionStorage`, `MySQLSessionStorage`, `PostgreSQLSessionStorage`, `RedisSessionStorage`) cover a variety of production-grade storage options.
+The other storage adapters (`MongoDBSessionStorage`, `MySQLSessionStorage`, `PostgreSQLSessionStorage`, `RedisSessionStorage`) cover a variety of production-grade storage options, but require further setup from the app.
+
+By default, this is how each runtime adapter behaves:
+
+- Node will use `SQLiteSessionStorage`, saving to a local `database.sqlite` file. This enables you to quickly set up a running app with persistent storage.
+- CloudFlare will load `MemorySessionStorage` because there is no option we can use a default that doesn't require configuration, but it won't be able to properly load sessions without a distributed database. You **_must_** change this setting for CF workers.
 
 If you wish to have an alternative storage solution, you must use a `CustomSessionStorage` solution in your production app- you can reference our [usage example with redis](usage/customsessions.md) to get started.
 

--- a/docs/usage/customsessions.md
+++ b/docs/usage/customsessions.md
@@ -8,7 +8,7 @@ This library comes with various session management options:
 - `MySQLSessionStorage`
 - `PostgreSQLSessionStorage`
 - `RedisSessionStorage`
-- `SQLiteSessionStorage` - uses the file-based SQLite package, and is the default storage option on `config`.
+- `SQLiteSessionStorage`
 
 If you wish to use an alternative session storage solution for production, you'll need to set up a `CustomSessionStorage`, which you can then use in initializing your `config`. The `CustomSessionStorage` class expects to be initialized with the following three mandatory callbacks that link to your chosen storage solution and map to the `storeSession`, `loadSession`, and `deleteSession` methods on the class.
 

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -3,6 +3,7 @@ import Cookies from 'cookies';
 import * as ShopifyErrors from '../error';
 import {validateConfig} from '../config';
 import {ApiVersion, ConfigParams} from '../base-types';
+import {MemorySessionStorage} from '../auth/session/storage/memory';
 
 jest.mock('cookies');
 
@@ -15,6 +16,7 @@ const validParams: ConfigParams = {
   isEmbeddedApp: true,
   isPrivateApp: false,
   logFile: 'some-file-path.txt',
+  sessionStorage: new MemorySessionStorage(),
 };
 
 const originalWarn = console.warn;

--- a/src/adapters/cf-worker/adapter.ts
+++ b/src/adapters/cf-worker/adapter.ts
@@ -1,3 +1,4 @@
+import {ShopifyError} from '../../error';
 import {
   canonicalizeHeaders,
   flatHeaders,
@@ -47,4 +48,10 @@ export async function workerFetch({
     body: respBody,
     headers: canonicalizeHeaders(Object.fromEntries(resp.headers.entries())),
   };
+}
+
+export function workerCreateDefaultStorage(): never {
+  throw new ShopifyError(
+    'You must specify a session storage implementation for CloudFlare workers',
+  );
 }

--- a/src/adapters/cf-worker/index.ts
+++ b/src/adapters/cf-worker/index.ts
@@ -4,14 +4,17 @@ import {
   setAbstractConvertResponseFunc,
 } from '../../runtime/http';
 import {setCrypto} from '../../runtime/crypto';
+import {setAbstractCreateDefaultStorage} from '../../runtime/session';
 
 import {
   workerFetch,
   workerConvertRequest,
   workerConvertResponse,
+  workerCreateDefaultStorage,
 } from './adapter';
 
 setAbstractFetchFunc(workerFetch);
 setAbstractConvertRequestFunc(workerConvertRequest);
 setAbstractConvertResponseFunc(workerConvertResponse);
+setAbstractCreateDefaultStorage(workerCreateDefaultStorage);
 setCrypto(crypto as any);

--- a/src/adapters/node/adapter.ts
+++ b/src/adapters/node/adapter.ts
@@ -1,7 +1,9 @@
 import type {IncomingMessage, ServerResponse} from 'http';
+import path from 'path';
 
 import fetch from 'node-fetch';
 
+import {SQLiteSessionStorage} from '../../auth/session/storage/sqlite';
 import {
   AdapterArgs,
   canonicalizeHeaders,
@@ -70,4 +72,13 @@ export async function nodeFetch({
     body: respBody,
     headers: canonicalizeHeaders(Object.fromEntries(resp.headers.entries())),
   };
+}
+
+export function nodeCreateDefaultStorage() {
+  const dbFile = path.join(
+    require.main ? path.dirname(require.main.filename) : process.cwd(),
+    'database.sqlite',
+  );
+
+  return new SQLiteSessionStorage(dbFile);
 }

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -6,14 +6,17 @@ import {
   setAbstractConvertResponseFunc,
 } from '../../runtime/http';
 import {setCrypto} from '../../runtime/crypto';
+import {setAbstractCreateDefaultStorage} from '../../runtime/session';
 
 import {
   nodeFetch,
   nodeConvertRequest,
   nodeConvertAndSendResponse,
+  nodeCreateDefaultStorage,
 } from './adapter';
 
 setAbstractFetchFunc(nodeFetch);
 setAbstractConvertRequestFunc(nodeConvertRequest);
 setAbstractConvertResponseFunc(nodeConvertAndSendResponse);
+setAbstractCreateDefaultStorage(nodeCreateDefaultStorage);
 setCrypto(crypto as any);

--- a/src/auth/session/session.ts
+++ b/src/auth/session/session.ts
@@ -1,5 +1,5 @@
-import {config} from '../../config';
 import {OnlineAccessInfo} from '../oauth/types';
+import {AuthScopes} from '../scopes';
 
 import {SessionInterface} from './types';
 
@@ -35,8 +35,8 @@ class Session implements SessionInterface {
     public isOnline: boolean,
   ) {}
 
-  public isActive(): boolean {
-    const scopesUnchanged = config.scopes.equals(this.scope);
+  public isActive(scopes: AuthScopes): boolean {
+    const scopesUnchanged = scopes.equals(this.scope);
     if (
       scopesUnchanged &&
       this.accessToken &&

--- a/src/auth/session/storage/README.md
+++ b/src/auth/session/storage/README.md
@@ -2,7 +2,7 @@
 
 This folder contains implementations of the `SessionStorage` interface that works with the most common databases.
 
-## SQLite (default)
+## SQLite (default for Node)
 
 ```js
 import Shopify from '@shopify/shopify-api';
@@ -107,7 +107,7 @@ setConfig({
 });
 ```
 
-## In-Memory (legacy)
+## In-Memory
 
 ```js
 import Shopify from '@shopify/shopify-api';
@@ -118,7 +118,7 @@ setConfig({
 });
 ```
 
-Note that all sessions will be lost if the app process gets restarted or redeployed. This session storage modal is for local development only.
+Note that all sessions will be lost if the app process gets restarted or redeployed. This session storage model is for local development only.
 
 ## Custom
 

--- a/src/auth/session/storage/sqlite.ts
+++ b/src/auth/session/storage/sqlite.ts
@@ -12,7 +12,7 @@ const defaultSQLiteSessionStorageOptions: SQLiteSessionStorageOptions = {
   sessionTableName: 'shopify_sessions',
 };
 
-export class SQLiteSessionStorage implements SessionStorage {
+export class SQLiteSessionStorage extends SessionStorage {
   private options: SQLiteSessionStorageOptions;
   private db: sqlite3.Database;
   private ready: Promise<void>;
@@ -21,6 +21,8 @@ export class SQLiteSessionStorage implements SessionStorage {
     private filename: string,
     opts: Partial<SQLiteSessionStorageOptions> = {},
   ) {
+    super();
+
     this.options = {...defaultSQLiteSessionStorageOptions, ...opts};
     this.db = new sqlite3.Database(this.filename);
     this.ready = this.init();

--- a/src/auth/session/types.ts
+++ b/src/auth/session/types.ts
@@ -1,4 +1,5 @@
 import {OnlineAccessInfo} from '../oauth/types';
+import {AuthScopes} from '../scopes';
 
 export interface SessionInterface {
   readonly id: string;
@@ -9,5 +10,5 @@ export interface SessionInterface {
   expires?: Date;
   accessToken?: string;
   onlineAccessInfo?: OnlineAccessInfo;
-  isActive(): boolean;
+  isActive(scopes: AuthScopes): boolean;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import {ShopifyError, PrivateAppError} from './error';
 import {SessionStorage} from './auth/session/session_storage';
 import {ConfigInterface, ConfigParams, LATEST_API_VERSION} from './base-types';
 import {AuthScopes} from './auth/scopes';
-import {MemorySessionStorage} from './auth/session/storage/memory';
+import {abstractCreateDefaultStorage} from './runtime/session';
 
 export function validateConfig(params: ConfigParams): ConfigInterface {
   const config: ConfigInterface = {
@@ -58,7 +58,8 @@ export function validateConfig(params: ConfigParams): ConfigInterface {
       params.scopes instanceof AuthScopes
         ? params.scopes
         : new AuthScopes(params.scopes),
-    sessionStorage: sessionStorage ?? new MemorySessionStorage(),
+    // We only want to use the default if there is no existing session storage.
+    sessionStorage: sessionStorage ?? abstractCreateDefaultStorage(),
     hostScheme: hostScheme ?? config.hostScheme,
     isPrivateApp:
       isPrivateApp === undefined ? config.isPrivateApp : isPrivateApp,

--- a/src/runtime/__tests__/all.test.ts
+++ b/src/runtime/__tests__/all.test.ts
@@ -1,2 +1,3 @@
 import '../crypto/__tests__/hmac.test';
 import '../http/__tests__/http.test';
+import '../session/__tests__/session.test';

--- a/src/runtime/session/__tests__/session.test.ts
+++ b/src/runtime/session/__tests__/session.test.ts
@@ -1,0 +1,19 @@
+import {abstractCreateDefaultStorage} from '../index';
+
+describe('Runtime session storage', () => {
+  test('creates an object that implements the interface', () => {
+    try {
+      const storage = abstractCreateDefaultStorage();
+
+      expect(storage).toHaveProperty('storeSession');
+      expect(storage).toHaveProperty('loadSession');
+      expect(storage).toHaveProperty('deleteSession');
+    } catch (err) {
+      // CF workers are a special case, because we _must_ receive a session storage implementation, as there is no
+      // default that doesn't require user set up.
+      expect(err.message).toEqual(
+        'You must specify a session storage implementation for CloudFlare workers',
+      );
+    }
+  });
+});

--- a/src/runtime/session/index.ts
+++ b/src/runtime/session/index.ts
@@ -1,0 +1,14 @@
+import {AbstractCreateDefaultStorageFunc} from './types';
+
+// eslint-disable-next-line import/no-mutable-exports
+export let abstractCreateDefaultStorage: AbstractCreateDefaultStorageFunc =
+  () => {
+    throw new Error(
+      "Missing adapter implementation for 'abstractCreateDefaultStorage' - make sure to import the appropriate adapter for your platform",
+    );
+  };
+export function setAbstractCreateDefaultStorage(
+  func: AbstractCreateDefaultStorageFunc,
+) {
+  abstractCreateDefaultStorage = func;
+}

--- a/src/runtime/session/types.ts
+++ b/src/runtime/session/types.ts
@@ -1,0 +1,3 @@
+import {SessionStorage} from '../../auth/session/session_storage';
+
+export type AbstractCreateDefaultStorageFunc = () => SessionStorage;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -53,7 +53,6 @@
   "exclude": [
     "src/base-rest-resource.ts",
     "src/auth/**/*.ts",
-    "src/runtime/**/*.ts",
     "src/utils/**/*.ts",
     "src/adapters/**/*.ts",
     "src/webhooks/**/*.ts",


### PR DESCRIPTION
### WHY are these changes introduced?

Finalizes #463

For node apps, we want to use SQLite as our default session storage as it is a much superior solution to in-memory, but that won't work on CF workers. Unfortunately, there isn't a default we can use for workers, since every other option would require the user to provide a server.

### WHAT is this pull request doing?

Adding tooling for each runtime to configure its own default session storage strategy so that we can have different behaviour.

For CF workers specifically, we're exploding with a sane message to inform the user of what they're lacking.