### PR TITLE
Update TS config, remove exports from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "test:all": "jest",
     "test": "jest --selectProjects library",
+    "pretest:adapters": "yarn build",
     "test:adapters": "jest --selectProjects adapters:node adapters:cf-worker",
     "test:session_storage": "jest --selectProjects session_storage",
     "test:rest_resources": "ls src/rest-resources/__tests__ | xargs -I \"{}\" sh -c 'yarn jest --testPathPattern=\\\"{}\\\" || exit 255'",

--- a/package.json
+++ b/package.json
@@ -2,14 +2,8 @@
   "name": "@shopify/shopify-api",
   "version": "5.0.1",
   "description": "Shopify API Library for Node - accelerate development with support for authentication, graphql proxy, webhooks",
-  "exports": {
-    ".": "./dist/src/index.js",
-    "./oauth": "./dist/src/auth/oauth/index.js",
-    "./webhooks": "./dist/src/webhooks/registry.js",
-    "./adapters/node": "./dist/src/adapters/node/index.js",
-    "./adapters/cf-worker": "./dist/src/adapters/cf-worker/index.js"
-  },
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "prettier": "@shopify/prettier-config",
   "scripts": {
     "test:all": "jest",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,7 @@
     "typeRoots": ["./node_modules/@types"],
     "outDir": "./dist",
     "baseUrl": ".",
-    "rootDir": "."
+    "rootDir": "src"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/test/*", "**/__tests__/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6453,9 +6453,9 @@ typedarray-to-buffer@^3.1.5:
     is-typedarray "^1.0.0"
 
 typescript@^4.6.3:
-  version "4.6.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz"
-  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### WHY are these changes introduced?

Using `exports` in `package.json` (for specifying sub-modules) seemed to create `tsc` problems when trying to import in the express layer package.

### WHAT is this pull request doing?

Main change is to remove `exports` from `package.json` and use `main` attributed instead.
Additionally:
- set `rootDir` to `src` in `tsconfig.json`, to avoid having `dist/src` vs. just `dist`
- upgrade TypeScript to `4.7.4`