### PR TITLE
Refactor clients and tests to use isomorphic mock

### DIFF
--- a/src/__tests__/test-helper.ts
+++ b/src/__tests__/test-helper.ts
@@ -6,7 +6,7 @@ import {MemorySessionStorage} from '../session/storage/memory';
 import {JwtPayload} from '../utils/types';
 import {getHMACKey} from '../utils/get-hmac-key';
 import {mockTestRequests} from '../adapters/mock/mock_test_requests';
-import {NormalizedResponse} from '../runtime/http';
+import {canonicalizeHeaders, NormalizedResponse} from '../runtime/http';
 import {RequestReturn} from '../clients/http_client/types';
 
 declare global {
@@ -69,10 +69,9 @@ export function queueMockResponse(
   partial: Partial<NormalizedResponse> = {},
 ) {
   mockTestRequests.queueResponse({
-    statusCode: 200,
-    statusText: 'OK',
-    headers: {},
-    ...partial,
+    statusCode: partial.statusCode ?? 200,
+    statusText: partial.statusText ?? 'OK',
+    headers: canonicalizeHeaders(partial.headers ?? {}),
     body,
   });
 }

--- a/src/__tests__/test-helper.ts
+++ b/src/__tests__/test-helper.ts
@@ -77,6 +77,10 @@ export function queueMockResponse(
   });
 }
 
+export function queueError(error: Error) {
+  mockTestRequests.queueError(error);
+}
+
 export function queueMockResponses(
   ...responses: Parameters<typeof queueMockResponse>[]
 ) {

--- a/src/__tests__/test-helper.ts
+++ b/src/__tests__/test-helper.ts
@@ -5,7 +5,7 @@ import {ConfigParams, LATEST_API_VERSION, Shopify} from '../base-types';
 import {MemorySessionStorage} from '../session/storage/memory';
 import {JwtPayload} from '../utils/types';
 import {getHMACKey} from '../utils/get-hmac-key';
-import {queueResponse} from '../adapters/mock/adapter';
+import {mockAdapter} from '../adapters/mock/adapter';
 import {NormalizedResponse} from '../runtime/http';
 import {RequestReturn} from '../clients/http_client/types';
 
@@ -68,7 +68,7 @@ export function queueMockResponse(
   body: string,
   partial: Partial<NormalizedResponse> = {},
 ) {
-  queueResponse({
+  mockAdapter.queueResponse({
     statusCode: 200,
     statusText: 'OK',
     headers: {},

--- a/src/__tests__/test-helper.ts
+++ b/src/__tests__/test-helper.ts
@@ -5,7 +5,7 @@ import {ConfigParams, LATEST_API_VERSION, Shopify} from '../base-types';
 import {MemorySessionStorage} from '../session/storage/memory';
 import {JwtPayload} from '../utils/types';
 import {getHMACKey} from '../utils/get-hmac-key';
-import {mockAdapter} from '../adapters/mock/adapter';
+import {mockTestRequests} from '../adapters/mock/mock_test_requests';
 import {NormalizedResponse} from '../runtime/http';
 import {RequestReturn} from '../clients/http_client/types';
 
@@ -68,7 +68,7 @@ export function queueMockResponse(
   body: string,
   partial: Partial<NormalizedResponse> = {},
 ) {
-  mockAdapter.queueResponse({
+  mockTestRequests.queueResponse({
     statusCode: 200,
     statusText: 'OK',
     headers: {},

--- a/src/adapters/mock/adapter.ts
+++ b/src/adapters/mock/adapter.ts
@@ -31,24 +31,12 @@ export async function mockFetch({
   headers = {},
   body,
 }: NormalizedRequest): Promise<NormalizedResponse> {
-  canonicalizeHeaders(headers);
-  const matchingRequest = mockTestRequests.findRequest({
+  mockTestRequests.requestList.push({
     url,
     method,
-    headers,
+    headers: canonicalizeHeaders(headers),
     body,
   });
-  if (matchingRequest === undefined) {
-    mockTestRequests.requestList.push({
-      url,
-      method,
-      headers,
-      body,
-      attempts: 1,
-    });
-  } else {
-    matchingRequest.attempts++;
-  }
 
   const next = mockTestRequests.responseList.shift()!;
   if (next instanceof Error) {

--- a/src/adapters/mock/adapter.ts
+++ b/src/adapters/mock/adapter.ts
@@ -1,10 +1,7 @@
-import fetch from 'node-fetch';
-
 import {MemorySessionStorage} from '../../session/storage/memory';
 import {
   AdapterArgs,
   canonicalizeHeaders,
-  flatHeaders,
   NormalizedRequest,
   NormalizedResponse,
 } from '../../runtime/http';
@@ -26,20 +23,75 @@ export async function mockConvertResponse(
   return Promise.resolve(response);
 }
 
+type RequestListEntry = NormalizedRequest & {attempts: number};
+type ResponseListEntry = NormalizedResponse | Error;
+let requestList: RequestListEntry[] = [];
+let responseList: ResponseListEntry[] = [];
+
+export function getOldestRequest(): NormalizedRequest {
+  if (requestList.length === 0) {
+    throw new Error('No requests have been made');
+  }
+  return requestList.shift()!;
+}
+
+export function getMostRecentRequest(): NormalizedRequest {
+  if (requestList.length === 0) {
+    throw new Error('No requests have been made');
+  }
+  return requestList.pop()!;
+}
+
+export function queueResponse(response: NormalizedResponse): void {
+  responseList.push(response);
+}
+
+export function queueError(error: Error): void {
+  responseList.push(error);
+}
+
 export async function mockFetch({
   url,
   method,
   headers = {},
   body,
 }: NormalizedRequest): Promise<NormalizedResponse> {
-  const resp = await fetch(url, {method, headers: flatHeaders(headers), body});
-  const respBody = await resp.text();
-  return {
-    statusCode: resp.status,
-    statusText: resp.statusText,
-    body: respBody,
-    headers: canonicalizeHeaders(Object.fromEntries(resp.headers.entries())),
-  };
+  canonicalizeHeaders(headers);
+  const matchingRequest = findRequest({url, method, headers, body});
+  if (typeof matchingRequest === 'undefined') {
+    requestList.push({url, method, headers, body, attempts: 1});
+  } else {
+    matchingRequest.attempts++;
+  }
+
+  const next = responseList.shift()!;
+  if (next instanceof Error) {
+    throw next;
+  }
+  return next;
+}
+
+export function findRequest(
+  request: NormalizedRequest,
+): RequestListEntry | undefined {
+  for (const matchingRequest of requestList) {
+    if (
+      matchingRequest.url === request.url &&
+      matchingRequest.method === request.method
+    ) {
+      if (request.body === undefined || request.body === null) {
+        return matchingRequest;
+      } else if (matchingRequest.body === request.body) {
+        return matchingRequest;
+      }
+    }
+  }
+  return undefined;
+}
+
+export function reset() {
+  requestList = [];
+  responseList = [];
 }
 
 export function mockCreateDefaultStorage() {

--- a/src/adapters/mock/mock_test_requests.ts
+++ b/src/adapters/mock/mock_test_requests.ts
@@ -1,0 +1,63 @@
+import {NormalizedRequest, NormalizedResponse} from '../../runtime/http';
+
+type RequestListEntry = NormalizedRequest & {attempts: number};
+type ResponseListEntry = NormalizedResponse | Error;
+
+interface MockedAdapter {
+  requestList: RequestListEntry[];
+  responseList: ResponseListEntry[];
+  getOldestRequest: () => NormalizedRequest;
+  getMostRecentRequest: () => NormalizedRequest;
+  queueResponse: (response: NormalizedResponse) => void;
+  queueError: (error: Error) => void;
+  findRequest: (request: NormalizedRequest) => RequestListEntry | undefined;
+  reset: () => void;
+}
+
+export const mockTestRequests: MockedAdapter = {
+  requestList: [],
+  responseList: [],
+
+  getOldestRequest(): NormalizedRequest {
+    if (this.requestList.length === 0) {
+      throw new Error('No requests have been made');
+    }
+    return this.requestList.shift()!;
+  },
+
+  getMostRecentRequest(): NormalizedRequest {
+    if (this.requestList.length === 0) {
+      throw new Error('No requests have been made');
+    }
+    return this.requestList.pop()!;
+  },
+
+  queueResponse(response: NormalizedResponse): void {
+    this.responseList.push(response);
+  },
+
+  queueError(error: Error): void {
+    this.responseList.push(error);
+  },
+
+  findRequest(request: NormalizedRequest): RequestListEntry | undefined {
+    for (const matchingRequest of this.requestList) {
+      if (
+        matchingRequest.url === request.url &&
+        matchingRequest.method === request.method
+      ) {
+        if (!request.body && !matchingRequest.body) {
+          return matchingRequest;
+        } else if (matchingRequest.body === request.body) {
+          return matchingRequest;
+        }
+      }
+    }
+    return undefined;
+  },
+
+  reset() {
+    this.requestList = [];
+    this.responseList = [];
+  },
+};

--- a/src/adapters/mock/mock_test_requests.ts
+++ b/src/adapters/mock/mock_test_requests.ts
@@ -1,36 +1,20 @@
 import {NormalizedRequest, NormalizedResponse} from '../../runtime/http';
 
-type RequestListEntry = NormalizedRequest & {attempts: number};
+type RequestListEntry = NormalizedRequest;
 type ResponseListEntry = NormalizedResponse | Error;
 
 interface MockedAdapter {
   requestList: RequestListEntry[];
   responseList: ResponseListEntry[];
-  getOldestRequest: () => NormalizedRequest;
-  getMostRecentRequest: () => NormalizedRequest;
   queueResponse: (response: NormalizedResponse) => void;
   queueError: (error: Error) => void;
-  findRequest: (request: NormalizedRequest) => RequestListEntry | undefined;
+  getRequest: () => RequestListEntry | undefined;
   reset: () => void;
 }
 
 export const mockTestRequests: MockedAdapter = {
   requestList: [],
   responseList: [],
-
-  getOldestRequest(): NormalizedRequest {
-    if (this.requestList.length === 0) {
-      throw new Error('No requests have been made');
-    }
-    return this.requestList.shift()!;
-  },
-
-  getMostRecentRequest(): NormalizedRequest {
-    if (this.requestList.length === 0) {
-      throw new Error('No requests have been made');
-    }
-    return this.requestList.pop()!;
-  },
 
   queueResponse(response: NormalizedResponse): void {
     this.responseList.push(response);
@@ -40,20 +24,8 @@ export const mockTestRequests: MockedAdapter = {
     this.responseList.push(error);
   },
 
-  findRequest(request: NormalizedRequest): RequestListEntry | undefined {
-    for (const matchingRequest of this.requestList) {
-      if (
-        matchingRequest.url === request.url &&
-        matchingRequest.method === request.method
-      ) {
-        if (!request.body && !matchingRequest.body) {
-          return matchingRequest;
-        } else if (matchingRequest.body === request.body) {
-          return matchingRequest;
-        }
-      }
-    }
-    return undefined;
+  getRequest(): RequestListEntry | undefined {
+    return this.requestList.shift();
   },
 
   reset() {

--- a/src/clients/graphql/__tests__/graphql_client.test.ts
+++ b/src/clients/graphql/__tests__/graphql_client.test.ts
@@ -1,6 +1,6 @@
 import * as ShopifyErrors from '../../../error';
 import {ShopifyHeader} from '../../../base-types';
-import {shopify} from '../../../__tests__/test-helper';
+import {queueMockResponse, shopify} from '../../../__tests__/test-helper';
 
 const DOMAIN = 'shop.myshopify.io';
 const QUERY = `
@@ -25,7 +25,7 @@ describe('GraphQL client', () => {
       domain: DOMAIN,
       accessToken: 'bork',
     });
-    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+    queueMockResponse(JSON.stringify(successResponse));
 
     const response = await client.query({data: QUERY});
 
@@ -47,7 +47,7 @@ describe('GraphQL client', () => {
       'X-Glib-Glob': 'goobers',
     };
 
-    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+    queueMockResponse(JSON.stringify(successResponse));
 
     await expect(
       client.query({extraHeaders: customHeader, data: QUERY}),
@@ -67,7 +67,7 @@ describe('GraphQL client', () => {
     shopify.config.isPrivateApp = true;
 
     const client = new shopify.clients.Graphql({domain: DOMAIN});
-    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+    queueMockResponse(JSON.stringify(successResponse));
 
     await expect(client.query({data: QUERY})).resolves.toEqual(
       buildExpectedResponse(successResponse),
@@ -131,7 +131,7 @@ describe('GraphQL client', () => {
       },
     };
 
-    fetchMock.mockResponseOnce(JSON.stringify(expectedResponse));
+    queueMockResponse(JSON.stringify(expectedResponse));
 
     await expect(client.query({data: queryWithVariables})).resolves.toEqual(
       buildExpectedResponse(expectedResponse),
@@ -194,7 +194,7 @@ describe('GraphQL client', () => {
       },
     };
 
-    fetchMock.mockResponseOnce(JSON.stringify(errorResponse));
+    queueMockResponse(JSON.stringify(errorResponse));
 
     await expect(() => client.query({data: query})).rejects.toThrow(
       new ShopifyErrors.GraphqlQueryError({

--- a/src/clients/graphql/__tests__/storefront_client.test.ts
+++ b/src/clients/graphql/__tests__/storefront_client.test.ts
@@ -1,4 +1,4 @@
-import {shopify} from '../../../__tests__/test-helper';
+import {shopify, queueMockResponse} from '../../../__tests__/test-helper';
 import {ShopifyHeader} from '../../../base-types';
 
 const DOMAIN = 'shop.myshopify.io';
@@ -25,7 +25,7 @@ describe('Storefront GraphQL client', () => {
       accessToken: 'bork',
     });
 
-    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+    queueMockResponse(JSON.stringify(successResponse));
 
     await expect(client.query({data: QUERY})).resolves.toEqual(
       buildExpectedResponse(successResponse),
@@ -48,7 +48,7 @@ describe('Storefront GraphQL client', () => {
 
     const client = new shopify.clients.Storefront({domain: DOMAIN});
 
-    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+    queueMockResponse(JSON.stringify(successResponse));
 
     await expect(client.query({data: QUERY})).resolves.toEqual(
       buildExpectedResponse(successResponse),

--- a/src/clients/http_client/__tests__/http_client.test.ts
+++ b/src/clients/http_client/__tests__/http_client.test.ts
@@ -850,7 +850,7 @@ describe('HTTP client', () => {
         body: {errors: 'Error 500'},
         code: 500,
         statusText: 'Error 500',
-        headers: {'X-Text-Header': 'Error 500'},
+        headers: {'X-Text-Header': ['Error 500']},
       },
     });
   });
@@ -872,7 +872,7 @@ describe('HTTP client', () => {
         body: {errors: 'Error 429'},
         code: 429,
         statusText: 'Error 429',
-        headers: {'X-Text-Header': 'Error 429', 'Retry-After': '100'},
+        headers: {'X-Text-Header': ['Error 429'], 'Retry-After': ['100']},
         retryAfter: 100,
       },
     });
@@ -894,7 +894,7 @@ describe('HTTP client', () => {
         body: {errors: 'Error 403'},
         code: 403,
         statusText: 'Error 403',
-        headers: {'X-Text-Header': 'Error 403'},
+        headers: {'X-Text-Header': ['Error 403']},
       },
     });
   });

--- a/src/clients/http_client/__tests__/http_client.test.ts
+++ b/src/clients/http_client/__tests__/http_client.test.ts
@@ -1,6 +1,7 @@
 import {
   buildExpectedResponse,
   buildMockResponse,
+  queueError,
   queueMockResponse,
   queueMockResponses,
   shopify,
@@ -345,19 +346,14 @@ describe('HTTP client', () => {
     await testErrorResponse(429, ShopifyErrors.HttpThrottlingError, true);
     await testErrorResponse(500, ShopifyErrors.HttpInternalError, true);
 
-    // fetchMock.mockRejectOnce(() => Promise.reject());
-    // await testErrorResponse(null, ShopifyErrors.HttpRequestError, false);
-
-    // eslint-disable-next-line no-warning-comments
-    // TODO: fix this test
-    // class MyError extends Error {
-    //   constructor(...args: any) {
-    //     super(...args);
-    //     Object.setPrototypeOf(this, new.target.prototype);
-    //   }
-    // }
-    // queueError(new MyError());
-    // await testErrorResponse(null, MyError, false);
+    class MyError extends Error {
+      constructor(...args: any) {
+        super(...args);
+        Object.setPrototypeOf(this, new.target.prototype);
+      }
+    }
+    queueError(new MyError());
+    await testErrorResponse(null, MyError, false);
   });
 
   it('allows custom headers', async () => {

--- a/src/clients/http_client/http_client.ts
+++ b/src/clients/http_client/http_client.ts
@@ -1,4 +1,3 @@
-import fetch, {RequestInit, Response} from 'node-fetch';
 import {Method, StatusCode} from '@shopify/network';
 
 import * as ShopifyErrors from '../../error';
@@ -7,6 +6,14 @@ import ProcessedQuery from '../../utils/processed-query';
 import {ConfigInterface, LogSeverity} from '../../base-types';
 import {createSHA256HMAC} from '../../runtime/crypto';
 import {HmacReturnFormat} from '../../runtime/crypto/types';
+import {
+  abstractFetch,
+  canonicalizeHeaders,
+  getHeader,
+  isOK,
+  NormalizedRequest,
+  NormalizedResponse,
+} from '../../runtime/http';
 
 import {
   DataType,
@@ -98,7 +105,7 @@ export function createHttpClientClass(config: ConfigInterface) {
         ...params.extraHeaders,
         'User-Agent': userAgent,
       };
-      let body = null;
+      let body;
       if (params.method === Method.Post || params.method === Method.Put) {
         const {type, data} = params as PostRequestParams;
         if (data) {
@@ -129,11 +136,12 @@ export function createHttpClientClass(config: ConfigInterface) {
       const url = `https://${this.domain}${this.getRequestPath(
         params.path,
       )}${ProcessedQuery.stringify(params.query)}`;
-      const options: RequestInit = {
-        method: params.method.toString(),
-        headers,
+      const request: NormalizedRequest = {
+        method: params.method,
+        url,
+        headers: canonicalizeHeaders(headers as any),
         body,
-      } as RequestInit;
+      };
 
       async function sleep(waitTime: number): Promise<void> {
         return new Promise((resolve) => setTimeout(resolve, waitTime));
@@ -142,7 +150,7 @@ export function createHttpClientClass(config: ConfigInterface) {
       let tries = 0;
       while (tries < maxTries) {
         try {
-          return await this.doRequest<T>(url, options);
+          return await this.doRequest<T>(request);
         } catch (error) {
           tries++;
           if (error instanceof ShopifyErrors.HttpRetriableError) {
@@ -184,26 +192,34 @@ export function createHttpClientClass(config: ConfigInterface) {
     }
 
     public async doRequest<T = unknown>(
-      url: string,
-      options: RequestInit,
+      request: NormalizedRequest,
     ): Promise<RequestReturn<T>> {
       try {
-        const response: Response = await fetch(url, options);
-        const body = await response.json().catch(() => ({}));
+        const response: NormalizedResponse = await abstractFetch(request);
+        let body: {[key: string]: string} | T = {};
 
-        if (response.ok) {
-          if (
-            response.headers &&
-            response.headers.has('X-Shopify-API-Deprecated-Reason')
-          ) {
+        if (response.body) {
+          try {
+            body = JSON.parse(response.body);
+          } catch (error) {
+            body = {};
+          }
+        }
+
+        if (isOK(response)) {
+          const deprecationReason = getHeader(
+            response.headers,
+            'X-Shopify-API-Deprecated-Reason',
+          );
+          if (deprecationReason) {
             const deprecation: DeprecationInterface = {
-              message: response.headers.get('X-Shopify-API-Deprecated-Reason'),
-              path: url,
+              message: deprecationReason,
+              path: request.url,
             };
 
-            if (options.body) {
+            if (request.body) {
               // This can only be a string, since we're always converting the body before calling this method
-              deprecation.body = `${(options.body as string).substring(
+              deprecation.body = `${(request.body as string).substring(
                 0,
                 100,
               )}...`;
@@ -235,55 +251,54 @@ export function createHttpClientClass(config: ConfigInterface) {
           }
 
           return {
-            body,
-            headers: response.headers,
+            body: body as T,
+            headers: response.headers ?? {},
           };
         } else {
           const errorMessages: string[] = [];
-          if (body.errors) {
-            errorMessages.push(JSON.stringify(body.errors, null, 2));
+          if ((body as any).errors) {
+            errorMessages.push(JSON.stringify((body as any).errors, null, 2));
           }
-          if (response.headers && response.headers.get('x-request-id')) {
+          const xRequestId = getHeader(response.headers, 'x-request-id');
+          if (xRequestId) {
             errorMessages.push(
-              `If you report this error, please include this id: ${response.headers.get(
-                'x-request-id',
-              )}`,
+              `If you report this error, please include this id: ${xRequestId}`,
             );
           }
 
           const errorMessage = errorMessages.length
             ? `:\n${errorMessages.join('\n')}`
             : '';
-          const headers = response.headers.raw();
-          const code = response.status;
+          const headers = response.headers ? response.headers : {};
+          const code = response.statusCode;
           const statusText = response.statusText;
 
           switch (true) {
-            case response.status === StatusCode.TooManyRequests: {
-              const retryAfter = response.headers.get('Retry-After');
+            case response.statusCode === StatusCode.TooManyRequests: {
+              const retryAfter = getHeader(response.headers, 'Retry-After');
               throw new ShopifyErrors.HttpThrottlingError({
                 message: `Shopify is throttling requests${errorMessage}`,
                 code,
                 statusText,
-                body,
+                body: body as any,
                 headers,
                 retryAfter: retryAfter ? parseFloat(retryAfter) : undefined,
               });
             }
-            case response.status >= StatusCode.InternalServerError:
+            case response.statusCode >= StatusCode.InternalServerError:
               throw new ShopifyErrors.HttpInternalError({
                 message: `Shopify internal error${errorMessage}`,
                 code,
                 statusText,
-                body,
+                body: body as any,
                 headers,
               });
             default:
               throw new ShopifyErrors.HttpResponseError({
-                message: `Received an error response (${response.status} ${response.statusText}) from Shopify${errorMessage}`,
+                message: `Received an error response (${response.statusCode} ${response.statusText}) from Shopify${errorMessage}`,
                 code,
                 statusText,
-                body,
+                body: body as any,
                 headers,
               });
           }

--- a/src/clients/http_client/http_client.ts
+++ b/src/clients/http_client/http_client.ts
@@ -191,127 +191,119 @@ export function createHttpClientClass(config: ConfigInterface) {
       return `/${path.replace(/^\//, '')}`;
     }
 
+    public throwFailedRequest(body: any, response: NormalizedResponse): never {
+      const errorMessages: string[] = [];
+      if (body.errors) {
+        errorMessages.push(JSON.stringify(body.errors, null, 2));
+      }
+      const xRequestId = getHeader(response.headers, 'x-request-id');
+      if (xRequestId) {
+        errorMessages.push(
+          `If you report this error, please include this id: ${xRequestId}`,
+        );
+      }
+
+      const errorMessage = errorMessages.length
+        ? `:\n${errorMessages.join('\n')}`
+        : '';
+      const headers = response.headers ? response.headers : {};
+      const code = response.statusCode;
+      const statusText = response.statusText;
+
+      switch (true) {
+        case response.statusCode === StatusCode.TooManyRequests: {
+          const retryAfter = getHeader(response.headers, 'Retry-After');
+          throw new ShopifyErrors.HttpThrottlingError({
+            message: `Shopify is throttling requests${errorMessage}`,
+            code,
+            statusText,
+            body,
+            headers,
+            retryAfter: retryAfter ? parseFloat(retryAfter) : undefined,
+          });
+        }
+        case response.statusCode >= StatusCode.InternalServerError:
+          throw new ShopifyErrors.HttpInternalError({
+            message: `Shopify internal error${errorMessage}`,
+            code,
+            statusText,
+            body,
+            headers,
+          });
+        default:
+          throw new ShopifyErrors.HttpResponseError({
+            message: `Received an error response (${response.statusCode} ${response.statusText}) from Shopify${errorMessage}`,
+            code,
+            statusText,
+            body,
+            headers,
+          });
+      }
+    }
+
     public async doRequest<T = unknown>(
       request: NormalizedRequest,
     ): Promise<RequestReturn<T>> {
-      try {
-        const response: NormalizedResponse = await abstractFetch(request);
-        let body: {[key: string]: string} | T = {};
+      const response: NormalizedResponse = await abstractFetch(request);
 
-        if (response.body) {
-          try {
-            body = JSON.parse(response.body);
-          } catch (error) {
-            body = {};
-          }
-        }
+      let body: {[key: string]: string} | string | T = {};
 
-        if (isOK(response)) {
-          const deprecationReason = getHeader(
-            response.headers,
-            'X-Shopify-API-Deprecated-Reason',
-          );
-          if (deprecationReason) {
-            const deprecation: DeprecationInterface = {
-              message: deprecationReason,
-              path: request.url,
-            };
-
-            if (request.body) {
-              // This can only be a string, since we're always converting the body before calling this method
-              deprecation.body = `${(request.body as string).substring(
-                0,
-                100,
-              )}...`;
-            }
-
-            const depHash = await createSHA256HMAC(
-              config.apiSecretKey,
-              JSON.stringify(deprecation),
-              HmacReturnFormat.Hex,
-            );
-
-            if (
-              !Object.keys(this.LOGGED_DEPRECATIONS).includes(depHash) ||
-              Date.now() - this.LOGGED_DEPRECATIONS[depHash] >=
-                HttpClient.DEPRECATION_ALERT_DELAY
-            ) {
-              this.LOGGED_DEPRECATIONS[depHash] = Date.now();
-
-              if (config.logFunction) {
-                const stack = new Error().stack;
-                const log = `API Deprecation Notice ${new Date().toLocaleString()} : ${JSON.stringify(
-                  deprecation,
-                )}\n    Stack Trace: ${stack}\n`;
-                await config.logFunction(LogSeverity.Warning, log);
-              } else {
-                console.warn('API Deprecation Notice:', deprecation);
-              }
-            }
-          }
-
-          return {
-            body: body as T,
-            headers: response.headers ?? {},
-          };
-        } else {
-          const errorMessages: string[] = [];
-          if ((body as any).errors) {
-            errorMessages.push(JSON.stringify((body as any).errors, null, 2));
-          }
-          const xRequestId = getHeader(response.headers, 'x-request-id');
-          if (xRequestId) {
-            errorMessages.push(
-              `If you report this error, please include this id: ${xRequestId}`,
-            );
-          }
-
-          const errorMessage = errorMessages.length
-            ? `:\n${errorMessages.join('\n')}`
-            : '';
-          const headers = response.headers ? response.headers : {};
-          const code = response.statusCode;
-          const statusText = response.statusText;
-
-          switch (true) {
-            case response.statusCode === StatusCode.TooManyRequests: {
-              const retryAfter = getHeader(response.headers, 'Retry-After');
-              throw new ShopifyErrors.HttpThrottlingError({
-                message: `Shopify is throttling requests${errorMessage}`,
-                code,
-                statusText,
-                body: body as any,
-                headers,
-                retryAfter: retryAfter ? parseFloat(retryAfter) : undefined,
-              });
-            }
-            case response.statusCode >= StatusCode.InternalServerError:
-              throw new ShopifyErrors.HttpInternalError({
-                message: `Shopify internal error${errorMessage}`,
-                code,
-                statusText,
-                body: body as any,
-                headers,
-              });
-            default:
-              throw new ShopifyErrors.HttpResponseError({
-                message: `Received an error response (${response.statusCode} ${response.statusText}) from Shopify${errorMessage}`,
-                code,
-                statusText,
-                body: body as any,
-                headers,
-              });
-          }
-        }
-      } catch (error) {
-        if (error instanceof ShopifyErrors.ShopifyError) {
-          throw error;
-        } else {
-          throw new ShopifyErrors.HttpRequestError(
-            `Failed to make Shopify HTTP request: ${error}`,
-          );
+      if (response.body) {
+        try {
+          body = JSON.parse(response.body);
+        } catch (error) {
+          body = response.body;
         }
       }
+
+      if (!isOK(response)) {
+        this.throwFailedRequest(body, response);
+      }
+
+      const deprecationReason = getHeader(
+        response.headers,
+        'X-Shopify-API-Deprecated-Reason',
+      );
+      if (deprecationReason) {
+        const deprecation: DeprecationInterface = {
+          message: deprecationReason,
+          path: request.url,
+        };
+
+        if (request.body) {
+          // This can only be a string, since we're always converting the body before calling this method
+          deprecation.body = `${(request.body as string).substring(0, 100)}...`;
+        }
+
+        const depHash = await createSHA256HMAC(
+          config.apiSecretKey,
+          JSON.stringify(deprecation),
+          HmacReturnFormat.Hex,
+        );
+
+        if (
+          !Object.keys(this.LOGGED_DEPRECATIONS).includes(depHash) ||
+          Date.now() - this.LOGGED_DEPRECATIONS[depHash] >=
+            HttpClient.DEPRECATION_ALERT_DELAY
+        ) {
+          this.LOGGED_DEPRECATIONS[depHash] = Date.now();
+
+          if (config.logFunction) {
+            const stack = new Error().stack;
+            const log = `API Deprecation Notice ${new Date().toLocaleString()} : ${JSON.stringify(
+              deprecation,
+            )}\n    Stack Trace: ${stack}\n`;
+            await config.logFunction(LogSeverity.Warning, log);
+          } else {
+            console.warn('API Deprecation Notice:', deprecation);
+          }
+        }
+      }
+
+      return {
+        body: body as T,
+        headers: response.headers ?? {},
+      };
     }
   };
 }

--- a/src/clients/http_client/types.ts
+++ b/src/clients/http_client/types.ts
@@ -1,5 +1,6 @@
 import {Method} from '@shopify/network';
-import {Headers} from 'node-fetch';
+
+import {Headers} from '../../runtime/http';
 
 export interface HeaderParams {
   [key: string]: string | number;

--- a/src/clients/rest/__tests__/rest_client.test.ts
+++ b/src/clients/rest/__tests__/rest_client.test.ts
@@ -1,4 +1,8 @@
-import {shopify} from '../../../__tests__/test-helper';
+import {
+  queueMockResponse,
+  queueMockResponses,
+  shopify,
+} from '../../../__tests__/test-helper';
 import {DataType, GetRequestParams} from '../../http_client/types';
 import {RestRequestReturn, PageInfo} from '../types';
 import * as ShopifyErrors from '../../../error';
@@ -21,7 +25,7 @@ describe('REST client', () => {
       accessToken: 'dummy-token',
     });
 
-    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+    queueMockResponse(JSON.stringify(successResponse));
 
     await expect(client.get({path: 'products'})).resolves.toEqual(
       buildExpectedResponse(successResponse),
@@ -39,7 +43,7 @@ describe('REST client', () => {
       accessToken: 'dummy-token',
     });
 
-    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+    queueMockResponse(JSON.stringify(successResponse));
     const getRequest = {
       path: 'products',
       query: {
@@ -63,7 +67,7 @@ describe('REST client', () => {
       accessToken: 'dummy-token',
     });
 
-    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+    queueMockResponse(JSON.stringify(successResponse));
 
     const postData = {
       title: 'Test product',
@@ -89,7 +93,7 @@ describe('REST client', () => {
       accessToken: 'dummy-token',
     });
 
-    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+    queueMockResponse(JSON.stringify(successResponse));
 
     const postData = {
       title: 'Test product + something else',
@@ -119,7 +123,7 @@ describe('REST client', () => {
       accessToken: 'dummy-token',
     });
 
-    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+    queueMockResponse(JSON.stringify(successResponse));
 
     const putData = {
       title: 'Test product',
@@ -145,7 +149,7 @@ describe('REST client', () => {
       accessToken: 'dummy-token',
     });
 
-    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+    queueMockResponse(JSON.stringify(successResponse));
 
     await expect(client.delete({path: 'products/123'})).resolves.toEqual(
       buildExpectedResponse(successResponse),
@@ -168,7 +172,7 @@ describe('REST client', () => {
       'X-Not-A-Real-Header': 'some_value',
     };
 
-    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+    queueMockResponse(JSON.stringify(successResponse));
 
     await expect(
       client.get({path: 'products', extraHeaders: customHeaders}),
@@ -195,7 +199,7 @@ describe('REST client', () => {
       'This invalid info header will be ignored',
     ];
 
-    fetchMock.mockResponses([
+    queueMockResponses([
       JSON.stringify(successResponse),
       {headers: {link: linkHeaders.join(', ')}},
     ]);
@@ -220,7 +224,7 @@ describe('REST client', () => {
       `<${params.nextPageUrl}>; rel="next"`,
     ];
 
-    fetchMock.mockResponses(
+    queueMockResponses(
       [
         JSON.stringify(successResponse),
         {headers: {link: linkHeaders.join(', ')}},
@@ -265,7 +269,7 @@ describe('REST client', () => {
       `<${params.nextPageUrl}>; rel="next"`,
     ];
 
-    fetchMock.mockResponses(
+    queueMockResponses(
       [
         JSON.stringify(successResponse),
         {headers: {link: linkHeaders.join(', ')}},
@@ -307,7 +311,7 @@ describe('REST client', () => {
       `<${params.nextPageUrl}>; rel="next"`,
     ];
 
-    fetchMock.mockResponses(
+    queueMockResponses(
       [
         JSON.stringify(successResponse),
         {headers: {link: linkHeaders.join(', ')}},
@@ -347,7 +351,7 @@ describe('REST client', () => {
 
     const client = new shopify.clients.Rest({domain});
 
-    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+    queueMockResponse(JSON.stringify(successResponse));
 
     await expect(client.get({path: 'products'})).resolves.toEqual(
       buildExpectedResponse(successResponse),
@@ -378,7 +382,7 @@ describe('REST client', () => {
       accessToken: 'dummy-token',
     });
 
-    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+    queueMockResponse(JSON.stringify(successResponse));
 
     await expect(client.get({path: 'products.json'})).resolves.toEqual(
       buildExpectedResponse(successResponse),
@@ -396,7 +400,7 @@ describe('REST client', () => {
       accessToken: 'dummy-token',
     });
 
-    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+    queueMockResponse(JSON.stringify(successResponse));
 
     await expect(client.get({path: '/admin/some-path.json'})).resolves.toEqual(
       buildExpectedResponse(successResponse),

--- a/src/clients/rest/rest_client.ts
+++ b/src/clients/rest/rest_client.ts
@@ -1,3 +1,4 @@
+import {getHeader} from '../../runtime/http';
 import {ShopifyHeader} from '../../base-types';
 import {RequestParams, GetRequestParams} from '../http_client/types';
 import * as ShopifyErrors from '../../error';
@@ -47,7 +48,7 @@ export function createRestClientClass(params: CreateClientClassParams) {
 
       const ret: RestRequestReturn<T> = await super.request<T>(params);
 
-      const link = ret.headers.get('link');
+      const link = getHeader(ret.headers, 'link');
       if (link !== undefined) {
         const pageInfo: PageInfo = {
           limit: params.query?.limit

--- a/src/setup-jest.ts
+++ b/src/setup-jest.ts
@@ -1,9 +1,9 @@
 import './adapters/mock';
-import {reset, findRequest} from './adapters/mock/adapter';
+import {mockAdapter} from './adapters/mock/adapter';
 import {canonicalizeHeaders} from './runtime/http';
 
 beforeEach(() => {
-  reset();
+  mockAdapter.reset();
 });
 
 interface AssertHttpRequestParams {
@@ -58,7 +58,7 @@ expect.extend({
       query ? `?${query.replace(/\+/g, '%20')}` : ''
     }`;
 
-    const matchingRequest = findRequest({
+    const matchingRequest = mockAdapter.findRequest({
       url: searchUrl,
       method,
       headers: searchHeaders,

--- a/src/setup-jest.ts
+++ b/src/setup-jest.ts
@@ -49,7 +49,8 @@ expect.extend({
     path,
     query = '',
     headers = {},
-    data = null,
+    data = undefined,
+    attempts = 1,
   }: AssertHttpRequestParams) {
     const searchHeaders = canonicalizeHeaders(headers as any);
     const searchBody =
@@ -58,14 +59,14 @@ expect.extend({
       query ? `?${query.replace(/\+/g, '%20')}` : ''
     }`;
 
-    const matchingRequest = mockTestRequests.findRequest({
-      url: searchUrl,
-      method,
-      headers: searchHeaders,
-      body: searchBody!,
-    });
-    expect(matchingRequest).not.toBeNull();
-    expect(matchingRequest!.headers).toMatchObject(searchHeaders);
+    for (let i = 0; i < attempts; i++) {
+      const matchingRequest = mockTestRequests.getRequest();
+      expect(matchingRequest).not.toBeNull();
+      expect(matchingRequest!.url).toEqual(searchUrl);
+      expect(matchingRequest!.method).toEqual(method);
+      expect(matchingRequest!.headers).toMatchObject(searchHeaders);
+      expect(matchingRequest!.body).toEqual(searchBody);
+    }
 
     return {
       message: () => `expected to have seen the right HTTP requests`,

--- a/src/setup-jest.ts
+++ b/src/setup-jest.ts
@@ -1,14 +1,9 @@
-import fetchMock from 'jest-fetch-mock';
-
 import './adapters/mock';
+import {reset, findRequest} from './adapters/mock/adapter';
+import {canonicalizeHeaders} from './runtime/http';
 
-fetchMock.enableMocks();
-
-let currentCall = 0;
 beforeEach(() => {
-  fetchMock.mockReset();
-
-  currentCall = 0;
+  reset();
 });
 
 interface AssertHttpRequestParams {
@@ -18,17 +13,7 @@ interface AssertHttpRequestParams {
   query?: string;
   headers?: {[key: string]: unknown};
   data?: string | {[key: string]: unknown} | null;
-  tries?: number;
-}
-
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace jest {
-    interface Matchers<R> {
-      toBeWithinSecondsOf(compareDate: number, seconds: number): R;
-      toMatchMadeHttpRequest(): R;
-    }
-  }
+  attempts?: number;
 }
 
 expect.extend({
@@ -65,27 +50,22 @@ expect.extend({
     query = '',
     headers = {},
     data = null,
-    tries = 1,
   }: AssertHttpRequestParams) {
-    const bodyObject = data && typeof data !== 'string';
-    const maxCall = currentCall + tries;
-    for (let i = currentCall; i < maxCall; i++) {
-      currentCall++;
+    const searchHeaders = canonicalizeHeaders(headers as any);
+    const searchBody =
+      data && typeof data !== 'string' ? JSON.stringify(data) : data;
+    const searchUrl = `https://${domain}${path}${
+      query ? `?${query.replace(/\+/g, '%20')}` : ''
+    }`;
 
-      const mockCall = fetchMock.mock.calls[i];
-      expect(mockCall).not.toBeUndefined();
-
-      if (bodyObject && mockCall[1]) {
-        mockCall[1].body = JSON.parse(mockCall[1].body as string);
-      }
-
-      expect(mockCall[0]).toEqual(
-        `https://${domain}${path}${
-          query ? `?${query.replace(/\+/g, '%20')}` : ''
-        }`,
-      );
-      expect(mockCall[1]).toMatchObject({method, headers, body: data});
-    }
+    const matchingRequest = findRequest({
+      url: searchUrl,
+      method,
+      headers: searchHeaders,
+      body: searchBody!,
+    });
+    expect(matchingRequest).not.toBeNull();
+    expect(matchingRequest!.headers).toMatchObject(searchHeaders);
 
     return {
       message: () => `expected to have seen the right HTTP requests`,

--- a/src/setup-jest.ts
+++ b/src/setup-jest.ts
@@ -1,9 +1,9 @@
 import './adapters/mock';
-import {mockAdapter} from './adapters/mock/adapter';
+import {mockTestRequests} from './adapters/mock/mock_test_requests';
 import {canonicalizeHeaders} from './runtime/http';
 
 beforeEach(() => {
-  mockAdapter.reset();
+  mockTestRequests.reset();
 });
 
 interface AssertHttpRequestParams {
@@ -58,7 +58,7 @@ expect.extend({
       query ? `?${query.replace(/\+/g, '%20')}` : ''
     }`;
 
-    const matchingRequest = mockAdapter.findRequest({
+    const matchingRequest = mockTestRequests.findRequest({
       url: searchUrl,
       method,
       headers: searchHeaders,


### PR DESCRIPTION
### WHY are these changes introduced?

The `HttpClient` relied on `node-fetch` for `fetch()`, which means it wouldn't work in a CF Worker environment.

### WHAT is this pull request doing?

`HttpClient` is refactored to use `abstractFetch` and therefore should be independent of the platform it's on (i.e., uses isomorphic framework).

Also included in this is the removal of `node-fetch` and `jest-fetch-mock` from the mock adapter.