### PR TITLE
Use object in Session constructor

### DIFF
--- a/docs/migrating_to_isomorphic.md
+++ b/docs/migrating_to_isomorphic.md
@@ -97,7 +97,7 @@ async function handleFetch(request: Request): Promise<Response> {
 },
 ```
 
-## Changes to `SessionStorage`
+## Changes to `Session` and `SessionStorage`
 
 1. `SessionStorage` is no longer an interface, but an abstract class. If you're using your own implementation of the interface, you need to replace `implements SessionStorage` with `extends SessionStorage`.
    <div>Before
@@ -131,6 +131,37 @@ async function handleFetch(request: Request): Promise<Response> {
 
    ```ts
    import {MemorySessionStorage} from '@shopify/shopify-api/session-storage/memory';
+   ```
+
+   </div>
+
+1. The `Session` constructor now takes an object which allows all properties of a session, and `Session.cloneSession` was removed since we can use a session as arguments for the clone.
+   <div>Before
+
+   ```ts
+   import {Session} from '@shopify/shopify-api';
+   const session = new Session(
+     'session-id',
+     'shop.myshopify.com',
+     'state1234',
+     true,
+   );
+   session.accessToken = 'token';
+   const clone = Session.cloneSession(session, 'newId');
+   ```
+
+   </div><div>After
+
+   ```ts
+   import {Session} from '@shopify/shopify-api';
+   const session = new Session({
+     id: 'session-id',
+     shop: 'shop.myshopify.com',
+     state: 'state1234',
+     isOnline: true,
+     accessToken: 'token',
+   });
+   const clone = new Session({...session, id: 'newId'});
    ```
 
    </div>

--- a/src/__tests__/test-helper.ts
+++ b/src/__tests__/test-helper.ts
@@ -126,9 +126,14 @@ export async function createAndSaveDummySession({
   expires?: Date;
   accessToken?: string;
 }): Promise<Session> {
-  const session = new Session(sessionId, shop, 'state', isOnline);
-  session.expires = expires;
-  session.accessToken = accessToken;
+  const session = new Session({
+    id: sessionId,
+    shop,
+    state: 'state',
+    isOnline,
+    expires,
+    accessToken,
+  });
   await expect(
     shopify.config.sessionStorage.storeSession(session),
   ).resolves.toEqual(true);

--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -206,14 +206,13 @@ function createSession({
   stateFromCookie: string;
   isOnline: boolean;
 }): SessionInterface {
-  let session: Session;
-
   if (
     !isOnline &&
     (postResponse.body as OnlineAccessResponse).associated_user
   ) {
     throw new ShopifyErrors.InvalidOAuthError(
-      "Attempted to complete offline OAuth flow, but received an online token response. This is likely because you're not setting the isOnline parameter consistently between begin() and callback()",
+      'Attempted to complete offline OAuth flow, but received an online token response. This is likely because ' +
+        "you're not setting the isOnline parameter consistently between begin() and callback()",
     );
   }
 
@@ -222,7 +221,8 @@ function createSession({
     !(postResponse.body as OnlineAccessResponse).associated_user
   ) {
     throw new ShopifyErrors.InvalidOAuthError(
-      "Attempted to complete online OAuth flow, but received an offline token response. This is likely because you're not setting the isOnline parameter consistently between begin() and callback()",
+      'Attempted to complete online OAuth flow, but received an offline token response. This is likely because ' +
+        "you're not setting the isOnline parameter consistently between begin() and callback()",
     );
   }
 
@@ -243,24 +243,27 @@ function createSession({
       sessionId = uuidv4();
     }
 
-    session = new Session(sessionId, shop, stateFromCookie, isOnline);
-    session.accessToken = access_token;
-    session.scope = scope;
-    session.expires = sessionExpiration;
-    session.onlineAccessInfo = rest;
+    return new Session({
+      id: sessionId,
+      shop,
+      state: stateFromCookie,
+      isOnline,
+      accessToken: access_token,
+      scope,
+      expires: sessionExpiration,
+      onlineAccessInfo: rest,
+    });
   } else {
     const responseBody = postResponse.body as AccessTokenResponse;
-    session = new Session(
-      createGetOfflineId(config)(shop),
+    return new Session({
+      id: createGetOfflineId(config)(shop),
       shop,
-      stateFromCookie,
+      state: stateFromCookie,
       isOnline,
-    );
-    session.accessToken = responseBody.access_token;
-    session.scope = responseBody.scope;
+      accessToken: responseBody.access_token,
+      scope: responseBody.scope,
+    });
   }
-
-  return session;
 }
 
 function throwIfPrivateApp(isPrivateApp: boolean, message: string): void {

--- a/src/session-storage/__tests__/battery-of-tests.ts
+++ b/src/session-storage/__tests__/battery-of-tests.ts
@@ -10,40 +10,64 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
   it('can store and delete all kinds of sessions', async () => {
     const sessionFactories = [
       async () => {
-        const session = new Session(sessionId, 'shop', 'state', false);
-        session.scope = shopify.config.scopes.toString();
-        session.accessToken = '123';
+        const session = new Session({
+          id: sessionId,
+          shop: 'shop',
+          state: 'state',
+          isOnline: false,
+          scope: shopify.config.scopes.toString(),
+          accessToken: '123',
+        });
         return session;
       },
       async () => {
-        const session = new Session(sessionId, 'shop', 'state', false);
         const expiryDate = new Date();
         expiryDate.setMinutes(expiryDate.getMinutes() + 60);
-        session.expires = expiryDate;
-        session.accessToken = '123';
-        session.scope = shopify.config.scopes.toString();
+        const session = new Session({
+          id: sessionId,
+          shop: 'shop',
+          state: 'state',
+          isOnline: false,
+          expires: expiryDate,
+          accessToken: '123',
+          scope: shopify.config.scopes.toString(),
+        });
         return session;
       },
       async () => {
-        const session = new Session(sessionId, 'shop', 'state', false);
-        session.expires = null as any;
-        session.scope = shopify.config.scopes.toString();
-        session.accessToken = '123';
+        const session = new Session({
+          id: sessionId,
+          shop: 'shop',
+          state: 'state',
+          isOnline: false,
+          expires: null as any,
+          scope: shopify.config.scopes.toString(),
+          accessToken: '123',
+        });
         return session;
       },
       async () => {
-        const session = new Session(sessionId, 'shop', 'state', false);
-        session.expires = undefined;
-        session.scope = shopify.config.scopes.toString();
-        session.accessToken = '123';
+        const session = new Session({
+          id: sessionId,
+          shop: 'shop',
+          state: 'state',
+          isOnline: false,
+          expires: undefined,
+          scope: shopify.config.scopes.toString(),
+          accessToken: '123',
+        });
         return session;
       },
       async () => {
-        const session = new Session(sessionId, 'shop', 'state', false);
-        session.onlineAccessInfo = {associated_user: {}} as any;
-        session.onlineAccessInfo!.associated_user.id = 123;
-        session.scope = shopify.config.scopes.toString();
-        session.accessToken = '123';
+        const session = new Session({
+          id: sessionId,
+          shop: 'shop',
+          state: 'state',
+          isOnline: false,
+          onlineAccessInfo: {associated_user: {id: 123}} as any,
+          scope: shopify.config.scopes.toString(),
+          accessToken: '123',
+        });
         return session;
       },
     ];
@@ -76,7 +100,12 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
     const storage = await storageFactory();
     storage.setConfig(shopify.config);
     const sessionId = 'test_session';
-    const session = new Session(sessionId, 'shop', 'state', true);
+    const session = new Session({
+      id: sessionId,
+      shop: 'shop',
+      state: 'state',
+      isOnline: true,
+    });
     (session as any).someField = 'lol';
 
     await expect(storage.storeSession(session)).resolves.toBe(true);
@@ -89,7 +118,12 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
     const storage = await storageFactory();
     storage.setConfig(shopify.config);
     const sessionId = 'test_session';
-    const session = new Session(sessionId, 'shop', 'state', true);
+    const session = new Session({
+      id: sessionId,
+      shop: 'shop',
+      state: 'state',
+      isOnline: true,
+    });
 
     await expect(storage.storeSession(session)).resolves.toBe(true);
     expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(
@@ -110,30 +144,30 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
     storage.setConfig(shopify.config);
     const prefix = 'find_sessions';
     const sessions = [
-      new Session(
-        `${prefix}_1`,
-        'find-shop1-sessions.myshopify.io',
-        'state',
-        true,
-      ),
-      new Session(
-        `${prefix}_2`,
-        'do-not-find-shop2-sessions.myshopify.io',
-        'state',
-        true,
-      ),
-      new Session(
-        `${prefix}_3`,
-        'find-shop1-sessions.myshopify.io',
-        'state',
-        true,
-      ),
-      new Session(
-        `${prefix}_4`,
-        'do-not-find-shop3-sessions.myshopify.io',
-        'state',
-        true,
-      ),
+      new Session({
+        id: `${prefix}_1`,
+        shop: 'find-shop1-sessions.myshopify.io',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: `${prefix}_2`,
+        shop: 'do-not-find-shop2-sessions.myshopify.io',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: `${prefix}_3`,
+        shop: 'find-shop1-sessions.myshopify.io',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: `${prefix}_4`,
+        shop: 'do-not-find-shop3-sessions.myshopify.io',
+        state: 'state',
+        isOnline: true,
+      }),
     ];
 
     for (const session of sessions) {
@@ -162,30 +196,30 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
     storage.setConfig(shopify.config);
     const prefix = 'delete_sessions';
     const sessions = [
-      new Session(
-        `${prefix}_1`,
-        'delete-shop1-sessions.myshopify.io',
-        'state',
-        true,
-      ),
-      new Session(
-        `${prefix}_2`,
-        'do-not-delete-shop2-sessions.myshopify.io',
-        'state',
-        true,
-      ),
-      new Session(
-        `${prefix}_3`,
-        'delete-shop1-sessions.myshopify.io',
-        'state',
-        true,
-      ),
-      new Session(
-        `${prefix}_4`,
-        'do-not-delete-shop3-sessions.myshopify.io',
-        'state',
-        true,
-      ),
+      new Session({
+        id: `${prefix}_1`,
+        shop: 'delete-shop1-sessions.myshopify.io',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: `${prefix}_2`,
+        shop: 'do-not-delete-shop2-sessions.myshopify.io',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: `${prefix}_3`,
+        shop: 'delete-shop1-sessions.myshopify.io',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: `${prefix}_4`,
+        shop: 'do-not-delete-shop3-sessions.myshopify.io',
+        state: 'state',
+        isOnline: true,
+      }),
     ];
 
     for (const session of sessions) {

--- a/src/session-storage/__tests__/custom.test.ts
+++ b/src/session-storage/__tests__/custom.test.ts
@@ -6,12 +6,12 @@ import {SessionStorageError} from '../../error';
 describe('custom session storage', () => {
   test('can perform core actions', async () => {
     const sessionId = 'test_session';
-    let session: Session | undefined = new Session(
-      sessionId,
-      'shop-url',
-      'state',
-      true,
-    );
+    let session: Session | undefined = new Session({
+      id: sessionId,
+      shop: 'shop-url',
+      state: 'state',
+      isOnline: true,
+    });
 
     let storeCalled = false;
     let loadCalled = false;
@@ -61,10 +61,30 @@ describe('custom session storage', () => {
   test('can perform optional actions', async () => {
     const prefix = 'custom_sessions';
     let sessions = [
-      new Session(`${prefix}_1`, 'shop1-sessions.myshopify.io', 'state', true),
-      new Session(`${prefix}_2`, 'shop2-sessions.myshopify.io', 'state', true),
-      new Session(`${prefix}_3`, 'shop1-sessions.myshopify.io', 'state', true),
-      new Session(`${prefix}_4`, 'shop3-sessions.myshopify.io', 'state', true),
+      new Session({
+        id: `${prefix}_1`,
+        shop: 'shop1-sessions.myshopify.io',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: `${prefix}_2`,
+        shop: 'shop2-sessions.myshopify.io',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: `${prefix}_3`,
+        shop: 'shop1-sessions.myshopify.io',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: `${prefix}_4`,
+        shop: 'shop3-sessions.myshopify.io',
+        state: 'state',
+        isOnline: true,
+      }),
     ];
 
     let deleteSessionsCalled = false;
@@ -113,12 +133,12 @@ describe('custom session storage', () => {
   test('missing optional actions generate warnings', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const prefix = 'custom_sessions';
-    const session = new Session(
-      `${prefix}_1`,
-      'shop1-sessions.myshopify.io',
-      'state',
-      true,
-    );
+    const session = new Session({
+      id: `${prefix}_1`,
+      shop: 'shop1-sessions.myshopify.io',
+      state: 'state',
+      isOnline: true,
+    });
 
     const storage = new CustomSessionStorage(
       () => {
@@ -150,12 +170,12 @@ describe('custom session storage', () => {
 
   test('failures and exceptions are raised', () => {
     const sessionId = 'test_session';
-    const session = new Session(
-      sessionId,
-      'shop-url.myshopify.io',
-      'state',
-      true,
-    );
+    const session = new Session({
+      id: sessionId,
+      shop: 'shop-url.myshopify.io',
+      state: 'state',
+      isOnline: true,
+    });
 
     let storage = new CustomSessionStorage(
       () => Promise.resolve(false),
@@ -202,13 +222,13 @@ describe('custom session storage', () => {
     const expiration = new Date();
     expiration.setDate(expiration.getDate() + 10);
 
-    let session: Session | undefined = new Session(
-      sessionId,
-      'shop',
-      'state',
-      true,
-    );
-    session.expires = expiration;
+    let session: Session | undefined = new Session({
+      id: sessionId,
+      shop: 'shop',
+      state: 'state',
+      isOnline: true,
+      expires: expiration,
+    });
 
     const storage = new CustomSessionStorage(
       () => {
@@ -236,30 +256,29 @@ describe('custom session storage', () => {
     const expiration = new Date();
     expiration.setDate(expiration.getDate() + 10);
 
-    let session: Session | undefined = new Session(
-      sessionId,
-      'test.myshopify.io',
-      '1234',
-      true,
-    );
-    session.scope = 'read_products';
-    session.expires = expiration;
-    session.isOnline = true;
-    session.accessToken = '12356';
-    session.onlineAccessInfo = {
-      associated_user_scope: 'read_products',
-      expires_in: 12345,
-      associated_user: {
-        id: 54321,
-        account_owner: true,
-        collaborator: true,
-        email: 'not@email',
-        email_verified: true,
-        first_name: 'first',
-        last_name: 'last',
-        locale: 'en',
+    let session: Session | undefined = new Session({
+      id: sessionId,
+      shop: 'test.myshopify.io',
+      state: '1234',
+      isOnline: true,
+      scope: 'read_products',
+      expires: expiration,
+      accessToken: '12356',
+      onlineAccessInfo: {
+        associated_user_scope: 'read_products',
+        expires_in: 12345,
+        associated_user: {
+          id: 54321,
+          account_owner: true,
+          collaborator: true,
+          email: 'not@email',
+          email_verified: true,
+          first_name: 'first',
+          last_name: 'last',
+          locale: 'en',
+        },
       },
-    };
+    });
 
     let serializedSession = '';
     const storage = new CustomSessionStorage(
@@ -287,12 +306,12 @@ describe('custom session storage', () => {
   it('allows empty fields in serialized object', async () => {
     const sessionId = 'test_session';
 
-    let session: Session | undefined = new Session(
-      sessionId,
-      'shop.myshopify.io',
-      'state',
-      true,
-    );
+    let session: Session | undefined = new Session({
+      id: sessionId,
+      shop: 'shop.myshopify.io',
+      state: 'state',
+      isOnline: true,
+    });
 
     let serializedSession = '';
     const storage = new CustomSessionStorage(

--- a/src/session-storage/__tests__/session-test-utils.test.ts
+++ b/src/session-storage/__tests__/session-test-utils.test.ts
@@ -5,16 +5,56 @@ import {sessionArraysEqual} from './session-test-utils';
 describe('test sessionArraysEqual', () => {
   it('returns true for two identically ordered arrays', () => {
     const sessionsExpected = [
-      new Session('test_sessions_1', 'shop1-sessions', 'state', true),
-      new Session('test_sessions_2', 'shop2-sessions', 'state', true),
-      new Session('test_sessions_3', 'shop1-sessions', 'state', true),
-      new Session('test_sessions_4', 'shop3-sessions', 'state', true),
+      new Session({
+        id: 'test_sessions_1',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_2',
+        shop: 'shop2-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_3',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_4',
+        shop: 'shop3-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
     ];
     const sessionsToCompare = [
-      new Session('test_sessions_1', 'shop1-sessions', 'state', true),
-      new Session('test_sessions_2', 'shop2-sessions', 'state', true),
-      new Session('test_sessions_3', 'shop1-sessions', 'state', true),
-      new Session('test_sessions_4', 'shop3-sessions', 'state', true),
+      new Session({
+        id: 'test_sessions_1',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_2',
+        shop: 'shop2-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_3',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_4',
+        shop: 'shop3-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
     ];
 
     expect(sessionArraysEqual(sessionsToCompare, sessionsExpected)).toBe(true);
@@ -22,16 +62,56 @@ describe('test sessionArraysEqual', () => {
 
   it('returns true for two arrays with same content but out of order', () => {
     const sessionsExpected = [
-      new Session('test_sessions_1', 'shop1-sessions', 'state', true),
-      new Session('test_sessions_2', 'shop2-sessions', 'state', true),
-      new Session('test_sessions_3', 'shop1-sessions', 'state', true),
-      new Session('test_sessions_4', 'shop3-sessions', 'state', true),
+      new Session({
+        id: 'test_sessions_1',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_2',
+        shop: 'shop2-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_3',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_4',
+        shop: 'shop3-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
     ];
     const sessionsToCompare = [
-      new Session('test_sessions_1', 'shop1-sessions', 'state', true),
-      new Session('test_sessions_3', 'shop1-sessions', 'state', true),
-      new Session('test_sessions_2', 'shop2-sessions', 'state', true),
-      new Session('test_sessions_4', 'shop3-sessions', 'state', true),
+      new Session({
+        id: 'test_sessions_1',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_3',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_2',
+        shop: 'shop2-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_4',
+        shop: 'shop3-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
     ];
 
     expect(sessionArraysEqual(sessionsToCompare, sessionsExpected)).toBe(true);
@@ -39,13 +119,38 @@ describe('test sessionArraysEqual', () => {
 
   it('returns false for two arrays not the same size', () => {
     const sessionsExpected = [
-      new Session('test_sessions_1', 'shop1-sessions', 'state', true),
+      new Session({
+        id: 'test_sessions_1',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
     ];
     const sessionsToCompare = [
-      new Session('test_sessions_1', 'shop1-sessions', 'state', true),
-      new Session('test_sessions_3', 'shop1-sessions', 'state', true),
-      new Session('test_sessions_2', 'shop2-sessions', 'state', true),
-      new Session('test_sessions_4', 'shop3-sessions', 'state', true),
+      new Session({
+        id: 'test_sessions_1',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_3',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_2',
+        shop: 'shop2-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_4',
+        shop: 'shop3-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
     ];
 
     expect(sessionArraysEqual(sessionsToCompare, sessionsExpected)).toBe(false);
@@ -53,34 +158,114 @@ describe('test sessionArraysEqual', () => {
 
   it('returns false for two arrays of the same size but different content', () => {
     const sessionsExpected = [
-      new Session('test_sessions_1', 'shop1-sessions', 'state', true),
-      new Session('test_sessions_3', 'shop1-sessions', 'state', true),
-      new Session('test_sessions_2', 'shop2-sessions', 'state', true),
-      new Session('test_sessions_4', 'shop3-sessions', 'state', true),
+      new Session({
+        id: 'test_sessions_1',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_3',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_2',
+        shop: 'shop2-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_4',
+        shop: 'shop3-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
     ];
     let sessionsToCompare = [
-      new Session('test_sessions_1', 'shop1-sessions', 'state', true),
-      new Session('test_sessions_3', 'shop1-sessions', 'state', true),
-      new Session('test_sessions_2', 'shop2-sessions', 'state', true),
-      new Session('test_sessions_5', 'shop3-sessions', 'state', true),
+      new Session({
+        id: 'test_sessions_1',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_3',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_2',
+        shop: 'shop2-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_5',
+        shop: 'shop3-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
     ];
 
     expect(sessionArraysEqual(sessionsToCompare, sessionsExpected)).toBe(false);
 
     sessionsToCompare = [
-      new Session('test_sessions_1', 'shop1-sessions', 'state', true),
-      new Session('test_sessions_3', 'shop1-sessions', 'state', true),
-      new Session('test_sessions_2', 'shop2-sessions', 'state', true),
-      new Session('test_sessions_4', 'shop4-sessions', 'state', true),
+      new Session({
+        id: 'test_sessions_1',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_3',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_2',
+        shop: 'shop2-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_4',
+        shop: 'shop4-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
     ];
 
     expect(sessionArraysEqual(sessionsToCompare, sessionsExpected)).toBe(false);
 
     sessionsToCompare = [
-      new Session('test_sessions_1', 'shop1-sessions', 'state', true),
-      new Session('test_sessions_3', 'shop1-sessions', 'state', true),
-      new Session('test_sessions_2', 'shop2-sessions', 'state', true),
-      new Session('test_sessions_4', 'shop3-sessions', 'state', false),
+      new Session({
+        id: 'test_sessions_1',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_3',
+        shop: 'shop1-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_2',
+        shop: 'shop2-sessions',
+        state: 'state',
+        isOnline: true,
+      }),
+      new Session({
+        id: 'test_sessions_4',
+        shop: 'shop3-sessions',
+        state: 'state',
+        isOnline: false,
+      }),
     ];
 
     expect(sessionArraysEqual(sessionsToCompare, sessionsExpected)).toBe(false);

--- a/src/session-storage/custom.ts
+++ b/src/session-storage/custom.ts
@@ -52,13 +52,7 @@ export class CustomSessionStorage extends SessionStorage {
 
         return result as SessionInterface;
       } else if (result instanceof Object && 'id' in result) {
-        let session = new Session(
-          result.id as string,
-          result.shop as string,
-          result.state as string,
-          result.isOnline as boolean,
-        );
-        session = {...session, ...(result as SessionInterface)};
+        const session = new Session({...(result as SessionInterface)});
 
         if (session.expires && typeof session.expires === 'string') {
           session.expires = new Date(session.expires);

--- a/src/session/__tests__/session.test.ts
+++ b/src/session/__tests__/session.test.ts
@@ -2,14 +2,31 @@ import {Session} from '../session';
 import {shopify} from '../../__tests__/test-helper';
 
 describe('session', () => {
-  it('can clone a session', () => {
-    const session = new Session(
-      'original',
-      'original-shop',
-      'original-state',
-      true,
-    );
-    const sessionClone = Session.cloneSession(session, 'new');
+  it('can create a session from another session', () => {
+    const session = new Session({
+      id: 'original',
+      shop: 'original-shop',
+      state: 'original-state',
+      isOnline: true,
+      accessToken: 'original-access-token',
+      expires: new Date(),
+      scope: 'original-scope',
+      onlineAccessInfo: {
+        expires_in: 1,
+        associated_user_scope: 'original-scope',
+        associated_user: {
+          id: 1,
+          first_name: 'original-first-name',
+          last_name: 'original-last-name',
+          email: 'original-email',
+          locale: 'original-locale',
+          email_verified: true,
+          account_owner: true,
+          collaborator: false,
+        },
+      },
+    });
+    const sessionClone = new Session({...session, id: 'clone'});
 
     expect(session.id).not.toEqual(sessionClone.id);
     expect(session.shop).toStrictEqual(sessionClone.shop);
@@ -26,23 +43,28 @@ describe('session', () => {
 
 describe('isActive', () => {
   it('returns true if session is active', () => {
-    const session = new Session('active', 'active-shop', 'test_state', true);
-    session.scope = 'test_scope';
-    session.accessToken = 'indeed';
-    session.expires = new Date(Date.now() + 86400);
+    const session = new Session({
+      id: 'active',
+      shop: 'active-shop',
+      state: 'test_state',
+      isOnline: true,
+      scope: 'test_scope',
+      accessToken: 'indeed',
+      expires: new Date(Date.now() + 86400),
+    });
 
     expect(session.isActive(shopify.config.scopes)).toBeTruthy();
   });
 
   it('returns false if session is not active', () => {
-    const session = new Session(
-      'not_active',
-      'inactive-shop',
-      'not_same',
-      true,
-    );
-    session.scope = 'test_scope';
-    session.expires = new Date(Date.now() - 1);
+    const session = new Session({
+      id: 'not_active',
+      shop: 'inactive-shop',
+      state: 'not_same',
+      isOnline: true,
+      scope: 'test_scope',
+      expires: new Date(Date.now() - 1),
+    });
     expect(session.isActive(shopify.config.scopes)).toBeFalsy();
   });
 });

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -1,39 +1,24 @@
 import {OnlineAccessInfo} from '../auth/oauth/types';
 import {AuthScopes} from '../auth/scopes';
 
-import {SessionInterface} from './types';
+import {SessionInterface, SessionParams} from './types';
 
 /**
  * Stores App information from logged in merchants so they can make authenticated requests to the Admin API.
  */
 export class Session implements SessionInterface {
-  public static cloneSession(session: Session, newId: string): Session {
-    const newSession = new Session(
-      newId,
-      session.shop,
-      session.state,
-      session.isOnline,
-    );
-
-    newSession.scope = session.scope;
-    newSession.expires = session.expires;
-    newSession.accessToken = session.accessToken;
-    newSession.onlineAccessInfo = session.onlineAccessInfo;
-
-    return newSession;
-  }
-
+  readonly id: string;
+  public shop: string;
+  public state: string;
+  public isOnline: boolean;
   public scope?: string;
   public expires?: Date;
   public accessToken?: string;
   public onlineAccessInfo?: OnlineAccessInfo;
 
-  constructor(
-    readonly id: string,
-    public shop: string,
-    public state: string,
-    public isOnline: boolean,
-  ) {}
+  constructor(params: SessionParams) {
+    Object.assign(this, params);
+  }
 
   public isActive(scopes: AuthScopes | string | string[]): boolean {
     const scopesObject =

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -7,7 +7,7 @@ import {ClientType} from '../base-types';
 
 import type {shopifySession} from '.';
 
-export interface SessionInterface {
+export interface SessionParams {
   readonly id: string;
   shop: string;
   state: string;
@@ -16,6 +16,9 @@ export interface SessionInterface {
   expires?: Date;
   accessToken?: string;
   onlineAccessInfo?: OnlineAccessInfo;
+}
+
+export interface SessionInterface extends SessionParams {
   isActive(scopes: AuthScopes | string | string[]): boolean;
 }
 

--- a/src/utils/__tests__/graphql_proxy.test.ts
+++ b/src/utils/__tests__/graphql_proxy.test.ts
@@ -80,13 +80,13 @@ describe('GraphQL proxy with session', () => {
       sid: 'abc123',
     };
 
-    const session = new Session(
-      `shop.myshopify.com_${jwtPayload.sub}`,
+    const session = new Session({
+      id: `shop.myshopify.com_${jwtPayload.sub}`,
       shop,
-      'state',
-      true,
-    );
-    session.accessToken = accessToken;
+      state: 'state',
+      isOnline: true,
+      accessToken,
+    });
     await shopify.config.sessionStorage.storeSession(session);
     token = await signJWT(shopify.config.apiSecretKey, jwtPayload);
   });
@@ -150,12 +150,12 @@ describe('GraphQL proxy', () => {
       },
       url: 'https://my-test-app.myshopify.io/auth/begin',
     };
-    const session = new Session(
-      `test-shop.myshopify.io_${jwtPayload.sub}`,
+    const session = new Session({
+      id: `test-shop.myshopify.io_${jwtPayload.sub}`,
       shop,
-      'state',
-      true,
-    );
+      state: 'state',
+      isOnline: true,
+    });
     shopify.config.sessionStorage.storeSession(session);
 
     await expect(


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, creating a session in the library isn't terribly easy, because we have a bit of a weird combination of constructor arguments and properties that need to be set directly. While there's nothing wrong with that, we can make things simpler by making it possible to instantiate sessions with all the properties we'll need.

### WHAT is this pull request doing?

Changing the `Session` constructor to take an object, which makes it possible to:
1. set all fields in a single call if we have more fields to set than the "basic" ones
2. clone a session by spreading an existing session rather than having a dedicated method for it