### PR TITLE
Move utils functions to appropriate objects

### DIFF
--- a/docs/migrating_to_isomorphic.md
+++ b/docs/migrating_to_isomorphic.md
@@ -234,7 +234,9 @@ The OAuth methods still behave the same way, but we've updated their signatures 
 ## Utility functions
 
 The previous `Shopify.Utils` object contained functions that relied on the global configuration object, but those have been refactored to use the instance-specific configuration.
-Utils functions are now located in `shopify.utils`.
+We also felt that the `Utils` object had some functions that belong to other parts of the library, so some of these functions have been moved to other sub-objects - keep an eye out for those changes in the list below!
+
+Here are all the specific changes that we made to the `Utils` object:
 
 1. The `storeSession` method was removed since sessions shouldn't be stored using the library unless the library is doing it. Apps can still save data to their sessions as they please, as long as the data is properly exported to the library via the configured `SessionStorage`.
 1. `validateHmac`, `generateLocalHmac`, `decodeSessionToken` are now `async`.
@@ -384,7 +386,7 @@ Utils functions are now located in `shopify.utils`.
 
    </div>
 
-1. `Shopify.Utils.graphqlProxy` is now `shopify.utils.graphqlProxy`, and it takes the body as an argument instead of parsing it from the request. This will make it easier for apps to use a body parser with this function.
+1. `Shopify.Utils.graphqlProxy` is now `shopify.clients.graphqlProxy`, and it takes the body as an argument instead of parsing it from the request. This will make it easier for apps to use a body parser with this function.
    <div>Before
 
    ```ts
@@ -394,7 +396,7 @@ Utils functions are now located in `shopify.utils`.
    </div><div>After
 
    ```ts
-   const response = await shopify.utils.graphqlProxy({
+   const response = await shopify.clients.graphqlProxy({
      body: req.rawBody, // From my app
      rawRequest: req,
      rawResponse: res,
@@ -403,17 +405,17 @@ Utils functions are now located in `shopify.utils`.
 
    </div>
 
-1. `Shopify.Utils.getEmbeddedAppUrl` is now `shopify.utils.getEmbeddedAppUrl`, is `async` and takes an object.
+1. `Shopify.Utils.getEmbeddedAppUrl` is now `shopify.auth.getEmbeddedAppUrl`, is `async` and takes an object.
    <div>Before
 
    ```ts
-   const redirectUrl = await Shopify.Utils.getEmbeddedAppUrl(req, res);
+   const redirectUrl = Shopify.Utils.getEmbeddedAppUrl(req, res);
    ```
 
    </div><div>After
 
    ```ts
-   const redirectUrl = await shopify.utils.getEmbeddedAppUrl({
+   const redirectUrl = await shopify.auth.getEmbeddedAppUrl({
      rawRequest: req,
      rawResponse: res,
    });

--- a/src/auth/__tests__/get-embedded-app-url.test.ts
+++ b/src/auth/__tests__/get-embedded-app-url.test.ts
@@ -9,7 +9,7 @@ describe('getEmbeddedAppUrl', () => {
 
   test('throws an error when no request is passed', async () => {
     await expect(
-      shopify.utils.getEmbeddedAppUrl({rawRequest: undefined}),
+      shopify.auth.getEmbeddedAppUrl({rawRequest: undefined}),
     ).rejects.toThrow(ShopifyErrors.MissingRequiredArgument);
   });
 
@@ -22,7 +22,7 @@ describe('getEmbeddedAppUrl', () => {
     };
 
     await expect(
-      shopify.utils.getEmbeddedAppUrl({rawRequest: req}),
+      shopify.auth.getEmbeddedAppUrl({rawRequest: req}),
     ).rejects.toThrow(ShopifyErrors.InvalidRequestError);
   });
 
@@ -36,7 +36,7 @@ describe('getEmbeddedAppUrl', () => {
     };
 
     await expect(
-      shopify.utils.getEmbeddedAppUrl({rawRequest: req}),
+      shopify.auth.getEmbeddedAppUrl({rawRequest: req}),
     ).rejects.toThrow(ShopifyErrors.InvalidRequestError);
   });
 
@@ -50,7 +50,7 @@ describe('getEmbeddedAppUrl', () => {
     };
 
     await expect(
-      shopify.utils.getEmbeddedAppUrl({rawRequest: req}),
+      shopify.auth.getEmbeddedAppUrl({rawRequest: req}),
     ).rejects.toThrow(ShopifyErrors.InvalidHostError);
   });
 
@@ -66,7 +66,7 @@ describe('getEmbeddedAppUrl', () => {
       },
     };
 
-    expect(await shopify.utils.getEmbeddedAppUrl({rawRequest: req})).toBe(
+    expect(await shopify.auth.getEmbeddedAppUrl({rawRequest: req})).toBe(
       `https://${host}/apps/${shopify.config.apiKey}`,
     );
   });

--- a/src/auth/get-embedded-app-url.ts
+++ b/src/auth/get-embedded-app-url.ts
@@ -1,8 +1,8 @@
 import * as ShopifyErrors from '../error';
 import {ConfigInterface} from '../base-types';
 import {abstractConvertRequest} from '../runtime/http';
+import {createSanitizeHost} from '../utils/shop-validator';
 
-import {createSanitizeHost} from './shop-validator';
 import {GetEmbeddedAppUrlParams} from './types';
 
 export function createGetEmbeddedAppUrl(config: ConfigInterface) {

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,10 +1,16 @@
 import {ConfigInterface} from '../base-types';
 
 import {createBegin, createCallback} from './oauth/oauth';
+import {
+  createGetEmbeddedAppUrl,
+  createBuildEmbeddedAppUrl,
+} from './get-embedded-app-url';
 
 export function shopifyAuth(config: ConfigInterface) {
   return {
     begin: createBegin(config),
     callback: createCallback(config),
+    getEmbeddedAppUrl: createGetEmbeddedAppUrl(config),
+    buildEmbeddedAppUrl: createBuildEmbeddedAppUrl(config),
   };
 }

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -1,5 +1,9 @@
+import {AdapterArgs} from '../runtime/http';
+
 import type {shopifyAuth} from '.';
 
 export * from './oauth/types';
+
+export interface GetEmbeddedAppUrlParams extends AdapterArgs {}
 
 export type ShopifyAuth = ReturnType<typeof shopifyAuth>;

--- a/src/clients/graphql/__tests__/graphql_proxy.test.ts
+++ b/src/clients/graphql/__tests__/graphql_proxy.test.ts
@@ -5,11 +5,11 @@ import {
   queueMockResponses,
   shopify,
   signJWT,
-} from '../../__tests__/test-helper';
-import {Session} from '../../session/session';
-import {InvalidSession, SessionNotFound} from '../../error';
-import {JwtPayload} from '../types';
-import {canonicalizeHeaders, NormalizedRequest} from '../../runtime/http';
+} from '../../../__tests__/test-helper';
+import {Session} from '../../../session/session';
+import {InvalidSession, SessionNotFound} from '../../../error';
+import {JwtPayload} from '../../../utils/types';
+import {canonicalizeHeaders, NormalizedRequest} from '../../../runtime/http';
 
 const successResponse = {
   data: {
@@ -53,7 +53,7 @@ describe('GraphQL proxy with session', () => {
         body: req.body,
       };
 
-      const testResponse = await shopify.utils.graphqlProxy({
+      const testResponse = await shopify.clients.graphqlProxy({
         body: request.body!,
         rawRequest: request,
       });
@@ -159,7 +159,7 @@ describe('GraphQL proxy', () => {
     shopify.config.sessionStorage.storeSession(session);
 
     await expect(
-      shopify.utils.graphqlProxy({
+      shopify.clients.graphqlProxy({
         body: '',
         rawRequest: request,
       }),
@@ -173,7 +173,7 @@ describe('GraphQL proxy', () => {
       url: 'https://my-test-app.myshopify.io/auth/begin',
     };
     await expect(
-      shopify.utils.graphqlProxy({
+      shopify.clients.graphqlProxy({
         body: '',
         rawRequest: request,
       }),

--- a/src/clients/graphql/graphql_proxy.ts
+++ b/src/clients/graphql/graphql_proxy.ts
@@ -1,10 +1,10 @@
-import {ConfigInterface} from '../base-types';
-import {RequestReturn} from '../clients/http_client/types';
-import * as ShopifyErrors from '../error';
-import {createGetCurrent} from '../session/get-current';
-import {createGraphqlClientClass} from '../clients/graphql/graphql_client';
+import {ConfigInterface} from '../../base-types';
+import {RequestReturn} from '../http_client/types';
+import * as ShopifyErrors from '../../error';
+import {createGetCurrent} from '../../session/get-current';
 
 import {GraphqlProxyParams} from './types';
+import {createGraphqlClientClass} from './graphql_client';
 
 export function createGraphqlProxy(config: ConfigInterface) {
   return async ({

--- a/src/clients/graphql/types.ts
+++ b/src/clients/graphql/types.ts
@@ -1,3 +1,8 @@
+import {AdapterArgs} from '../../runtime/http';
 import {PostRequestParams} from '../http_client/types';
 
 export type GraphqlParams = Omit<PostRequestParams, 'path' | 'type'>;
+
+export interface GraphqlProxyParams extends AdapterArgs {
+  body: string;
+}

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -4,6 +4,7 @@ import {createHttpClientClass} from './http_client/http_client';
 import {createRestClientClass} from './rest/rest_client';
 import {createGraphqlClientClass} from './graphql/graphql_client';
 import {createStorefrontClientClass} from './graphql/storefront_client';
+import {createGraphqlProxy} from './graphql/graphql_proxy';
 
 export interface CreateClientClassParams {
   config: ConfigInterface;
@@ -16,5 +17,6 @@ export function createClientClasses(config: ConfigInterface) {
     Rest: createRestClientClass({config, HttpClient}),
     Graphql: createGraphqlClientClass({config, HttpClient}),
     Storefront: createStorefrontClientClass({config, HttpClient}),
+    graphqlProxy: createGraphqlProxy(config),
   };
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,15 +2,10 @@ import {ConfigInterface} from '../base-types';
 
 import {createDecodeSessionToken} from './decode-session-token';
 import {nonce} from './nonce';
-import {createGraphqlProxy} from './graphql_proxy';
 import {safeCompare} from './safe-compare';
-import {createValidateHmac} from './hmac-validator';
 import {createSanitizeShop, createSanitizeHost} from './shop-validator';
+import {createValidateHmac} from './hmac-validator';
 import {createVersionCompatible} from './version-compatible';
-import {
-  createGetEmbeddedAppUrl,
-  createBuildEmbeddedAppUrl,
-} from './get-embedded-app-url';
 
 // eslint-disable-next-line no-warning-comments
 // TODO refactor utils functions to take in objects for consistency (and update docs)
@@ -18,13 +13,10 @@ export function shopifyUtils(config: ConfigInterface) {
   return {
     decodeSessionToken: createDecodeSessionToken(config),
     nonce,
-    graphqlProxy: createGraphqlProxy(config),
     safeCompare,
-    validateHmac: createValidateHmac(config),
     sanitizeShop: createSanitizeShop(config),
     sanitizeHost: createSanitizeHost(config),
+    validateHmac: createValidateHmac(config),
     versionCompatible: createVersionCompatible(config),
-    getEmbeddedAppUrl: createGetEmbeddedAppUrl(config),
-    buildEmbeddedAppUrl: createBuildEmbeddedAppUrl(config),
   };
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,5 +1,3 @@
-import {AdapterArgs} from '../runtime/http';
-
 import type {shopifyUtils} from '.';
 
 export interface JwtPayload {
@@ -12,12 +10,6 @@ export interface JwtPayload {
   iat: number;
   jti: string;
   sid: string;
-}
-
-export interface GetEmbeddedAppUrlParams extends AdapterArgs {}
-
-export interface GraphqlProxyParams extends AdapterArgs {
-  body: string;
 }
 
 export type ShopifyUtils = ReturnType<typeof shopifyUtils>;


### PR DESCRIPTION
### WHY are these changes introduced?

The `Utils` object was a little bloated with functions that weren't necessarily utility functions, but served a specific purpose.

### WHAT is this pull request doing?

Moving some functions around so they're closer to the objects to which they apply, namely:

- `Utils.getEmbeddedAppUrl` --> `auth.getEmbeddedAppUrl`
- `Utils.buildEmbeddedAppUrl` --> `auth.buildEmbeddedAppUrl`
- `Utils.graphqlProxy` --> `clients.graphqlProxy`

With this, `shopify.utils` now contains:

- `decodeSessionToken`
- `nonce`
- `safeCompare`
- `sanitizeShop`
- `sanitizeHost`
- `validateHmac`
- `versionCompatible`

all of which feel reasonably utils-y to me - though I'm on the fence whether `decodeSessionToken` should be in `auth` rather than utils.