### PR TITLE
Response returned in InvalidWebhookError should be converted first

### DIFF
--- a/src/webhooks/registry.ts
+++ b/src/webhooks/registry.ts
@@ -471,7 +471,7 @@ export function createProcess(config: ConfigInterface) {
     if (!isOK(response)) {
       throw new ShopifyErrors.InvalidWebhookError({
         message: errorMessage,
-        response,
+        response: returnResponse,
       });
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Response passed back through `InvalidWebhookError` is `NormalizedResponse`, which doesn't abstract the conversions from the developer (applies to Worker environments - response will already have been sent in Node environments).

### WHAT is this pull request doing?

Passing the converted response back instead.