### PR TITLE
Support spin stores by default

### DIFF
--- a/src/utils/__tests__/shop-validator.test.ts
+++ b/src/utils/__tests__/shop-validator.test.ts
@@ -6,6 +6,7 @@ const VALID_SHOP_URL_1 = 'someshop.myshopify.com';
 const VALID_SHOP_URL_2 = 'devshop.myshopify.io';
 const VALID_SHOP_URL_3 = 'test-shop.myshopify.com';
 const VALID_SHOP_URL_4 = 'dev-shop-.myshopify.io';
+const VALID_SHOP_URL_5 = 'super-cool.shopify.constellation.in.spin.dev';
 
 const INVALID_SHOP_URL_1 = 'notshopify.com';
 const INVALID_SHOP_URL_2 = '-invalid.myshopify.io';
@@ -36,6 +37,7 @@ describe('sanitizeShop', () => {
     expect(sanitizeShop(VALID_SHOP_URL_2)).toEqual(VALID_SHOP_URL_2);
     expect(sanitizeShop(VALID_SHOP_URL_3)).toEqual(VALID_SHOP_URL_3);
     expect(sanitizeShop(VALID_SHOP_URL_4)).toEqual(VALID_SHOP_URL_4);
+    expect(sanitizeShop(VALID_SHOP_URL_5)).toEqual(VALID_SHOP_URL_5);
   });
 
   test('returns null for invalid URLs', () => {

--- a/src/utils/shop-validator.ts
+++ b/src/utils/shop-validator.ts
@@ -12,7 +12,7 @@ export function sanitizeShop(
   shop: string,
   throwOnInvalid = false,
 ): string | null {
-  const domainsRegex = ['myshopify\\.com', 'myshopify\\.io'];
+  const domainsRegex = ['myshopify\\.com', 'myshopify\\.io', '.*\\.spin\\.dev'];
   if (Context.CUSTOM_SHOP_DOMAINS) {
     domainsRegex.push(
       ...Context.CUSTOM_SHOP_DOMAINS.map((regex) =>


### PR DESCRIPTION
### WHY are these changes introduced?

We want to automatically support stores that are hosted on spin environments, as it makes easier to test tools internally.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
