### PR TITLE
Fixes: Simplify `getHandler` signature, use uppercase/underscore format for storing topics

### DIFF
--- a/src/webhooks/__tests__/registry.test.ts
+++ b/src/webhooks/__tests__/registry.test.ts
@@ -577,9 +577,7 @@ describe('shopify.webhooks.addHandler', () => {
       ...genericRegistryEntry,
     });
     expect(Object.keys(webhookRegistry)).toHaveLength(1);
-    expect(Object.keys(webhookRegistry)).toEqual([
-      'PRODUCTS_CREATE',
-    ]);
+    expect(Object.keys(webhookRegistry)).toEqual(['PRODUCTS_CREATE']);
   });
 });
 
@@ -624,11 +622,14 @@ describe('shopify.webhooks.addHandlers', () => {
 
   it('adds handlers with lowercase/slash format to the webhook registry', async () => {
     await shopify.webhooks.addHandlers({
-      ['products/create']: {
+      'products/create': {
         path: '/webhooks',
         webhookHandler: genericWebhookHandler,
       },
-      ['products/delete']: {path: '/webhooks', webhookHandler: genericWebhookHandler},
+      'products/delete': {
+        path: '/webhooks',
+        webhookHandler: genericWebhookHandler,
+      },
     });
     expect(Object.keys(webhookRegistry)).toHaveLength(2);
     expect(Object.keys(webhookRegistry)).toEqual([

--- a/src/webhooks/__tests__/registry.test.ts
+++ b/src/webhooks/__tests__/registry.test.ts
@@ -618,7 +618,7 @@ describe('shopify.webhooks.getHandler', () => {
   });
 
   it('gets a nonexistent handler', async () => {
-    expect(shopify.webhooks.getHandler({topic: 'PRODUCTS'})).toBe(null);
+    expect(shopify.webhooks.getHandler('PRODUCTS')).toBe(null);
   });
 
   it('gets a handler', async () => {
@@ -626,7 +626,7 @@ describe('shopify.webhooks.getHandler', () => {
       topic: 'PRODUCTS',
       ...genericRegistryEntry,
     });
-    expect(shopify.webhooks.getHandler({topic: 'PRODUCTS'})).toStrictEqual({
+    expect(shopify.webhooks.getHandler('PRODUCTS')).toStrictEqual({
       path: '/webhooks',
       webhookHandler: genericWebhookHandler,
     });

--- a/src/webhooks/__tests__/registry.test.ts
+++ b/src/webhooks/__tests__/registry.test.ts
@@ -570,6 +570,17 @@ describe('shopify.webhooks.addHandler', () => {
 
     expect(webhookRegistry.PRODUCTS.path).toBe('/webhookspath');
   });
+
+  it('adds handler with lowercase/slash format to the webhook registry', async () => {
+    await shopify.webhooks.addHandler({
+      topic: 'products/create',
+      ...genericRegistryEntry,
+    });
+    expect(Object.keys(webhookRegistry)).toHaveLength(1);
+    expect(Object.keys(webhookRegistry)).toEqual([
+      'PRODUCTS_CREATE',
+    ]);
+  });
 });
 
 describe('shopify.webhooks.addHandlers', () => {
@@ -610,6 +621,21 @@ describe('shopify.webhooks.addHandlers', () => {
     );
     expect(webhookRegistry.PRODUCTS.path).toBe('/newerpath');
   });
+
+  it('adds handlers with lowercase/slash format to the webhook registry', async () => {
+    await shopify.webhooks.addHandlers({
+      ['products/create']: {
+        path: '/webhooks',
+        webhookHandler: genericWebhookHandler,
+      },
+      ['products/delete']: {path: '/webhooks', webhookHandler: genericWebhookHandler},
+    });
+    expect(Object.keys(webhookRegistry)).toHaveLength(2);
+    expect(Object.keys(webhookRegistry)).toEqual([
+      'PRODUCTS_CREATE',
+      'PRODUCTS_DELETE',
+    ]);
+  });
 });
 
 describe('shopify.webhooks.getHandler', () => {
@@ -627,6 +653,28 @@ describe('shopify.webhooks.getHandler', () => {
       ...genericRegistryEntry,
     });
     expect(shopify.webhooks.getHandler('PRODUCTS')).toStrictEqual({
+      path: '/webhooks',
+      webhookHandler: genericWebhookHandler,
+    });
+  });
+
+  it('gets a handler using lowercase and slash format', async () => {
+    shopify.webhooks.addHandler({
+      topic: 'PRODUCTS_CREATE',
+      ...genericRegistryEntry,
+    });
+    expect(shopify.webhooks.getHandler('products/create')).toStrictEqual({
+      path: '/webhooks',
+      webhookHandler: genericWebhookHandler,
+    });
+  });
+
+  it('gets a handler registered using lowercase and slash format using uppercase format', async () => {
+    shopify.webhooks.addHandler({
+      topic: 'products/create',
+      ...genericRegistryEntry,
+    });
+    expect(shopify.webhooks.getHandler('PRODUCTS_CREATE')).toStrictEqual({
       path: '/webhooks',
       webhookHandler: genericWebhookHandler,
     });

--- a/src/webhooks/registry.ts
+++ b/src/webhooks/registry.ts
@@ -145,6 +145,10 @@ export function buildQuery({
   `;
 }
 
+function topicForStorage(topic: string): string {
+  return topic.toUpperCase().replace(/\//g, '_');
+}
+
 export const webhookRegistry: {[topic: string]: WebhookRegistryEntry} = {};
 
 export function resetWebhookRegistry() {
@@ -157,7 +161,7 @@ export function resetWebhookRegistry() {
 
 export function addHandler(params: AddHandlerParams) {
   const {topic, ...rest} = params;
-  webhookRegistry[topic] = rest as WebhookRegistryEntry;
+  webhookRegistry[topicForStorage(topic)] = rest as WebhookRegistryEntry;
 }
 
 export function addHandlers(handlers: AddHandlersProps): void {
@@ -169,7 +173,7 @@ export function addHandlers(handlers: AddHandlersProps): void {
 }
 
 export function getHandler(topic: string): WebhookRegistryEntry | null {
-  return webhookRegistry[topic] ?? null;
+  return webhookRegistry[topicForStorage(topic)] ?? null;
 }
 
 export function getTopics(): string[] {
@@ -377,7 +381,7 @@ export function createProcess(config: ConfigInterface) {
       );
 
       if (safeCompare(generatedHash, hmac)) {
-        const graphqlTopic = topic.toUpperCase().replace(/\//g, '_');
+        const graphqlTopic = topicForStorage(topic);
         const webhookEntry = getHandler(graphqlTopic);
 
         if (webhookEntry) {

--- a/src/webhooks/registry.ts
+++ b/src/webhooks/registry.ts
@@ -24,7 +24,6 @@ import {
   BuildCheckQueryParams,
   BuildQueryParams,
   DeliveryMethod,
-  GetHandlerParams,
   RegisterParams,
   RegisterReturn,
   WebhookRegistryEntry,
@@ -169,9 +168,7 @@ export function addHandlers(handlers: AddHandlersProps): void {
   );
 }
 
-export function getHandler({
-  topic,
-}: GetHandlerParams): WebhookRegistryEntry | null {
+export function getHandler(topic: string): WebhookRegistryEntry | null {
   return webhookRegistry[topic] ?? null;
 }
 
@@ -273,7 +270,7 @@ export function createRegisterAll(config: ConfigInterface) {
     const topics = getTopics();
 
     for (const topic of topics) {
-      const handler = getHandler({topic});
+      const handler = getHandler(topic);
       if (handler) {
         const {path} = handler;
         const webhook: RegisterParams = {
@@ -381,9 +378,7 @@ export function createProcess(config: ConfigInterface) {
 
       if (safeCompare(generatedHash, hmac)) {
         const graphqlTopic = topic.toUpperCase().replace(/\//g, '_');
-        const webhookEntry = getHandler({
-          topic: graphqlTopic,
-        });
+        const webhookEntry = getHandler(graphqlTopic);
 
         if (webhookEntry) {
           try {

--- a/src/webhooks/types.ts
+++ b/src/webhooks/types.ts
@@ -90,8 +90,4 @@ export interface AddHandlerParams extends WebhookRegistryEntry {
   topic: string;
 }
 
-export interface GetHandlerParams {
-  topic: string;
-}
-
 export type ShopifyWebhooks = ReturnType<typeof shopifyWebhooks>;


### PR DESCRIPTION
### WHY are these changes introduced?

- The old `getHandler` method took a simple string as a parameter; the new one takes an object with a single string property.
- When storing handlers, we use the topic provided as-is; so if a handler was stored for `products/create` and someone searched for `PRODUCTS_CREATE`, it wouldn't be found.

### WHAT is this pull request doing?

- Return the `getHandler` method signature to a simple positional string parameter
- When adding handlers, convert the topic to uppercase and underscore format; likewise convert the provided topic to the same format when searching.
