### PR TITLE
Add await to handler call

### DIFF
--- a/src/webhooks/registry.ts
+++ b/src/webhooks/registry.ts
@@ -382,7 +382,7 @@ export function createProcess(
 
         if (handler) {
           try {
-            handler(graphqlTopic, domain, rawBody);
+            await handler(graphqlTopic, domain, rawBody);
             response.statusCode = StatusCode.Ok;
           } catch (error) {
             response.statusCode = StatusCode.InternalServerError;


### PR DESCRIPTION
### WHY are these changes introduced?

Call to `async` webhook handlers in `process` were not blocking.

### WHAT is this pull request doing?

- Add `await` to handler call.
- Add code to tests to block briefly to test for `await`.