### PR TITLE
Increase operations-per-run beyond default of 30

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           days-before-issue-stale: 60
           days-before-issue-close: 14
+          operations-per-run: 1000
           stale-issue-label: "Stale"
           stale-issue-message: >
             This issue is stale because it has been open for 90 days with no activity. It will be closed if no further action occurs in 14 days. 


### PR DESCRIPTION
### WHY are these changes introduced?

Our current close inactive issues workflow is hitting a 30 operations per run limit and not closing older inactive issues that should be closed.
![Screen Shot 2022-10-05 at 12 18 44 PM](https://user-images.githubusercontent.com/56687600/194110994-449a20d0-0d2d-4240-9af1-3c98078a5776.png)

### WHAT is this pull request doing?

Increase the `operations-per-run` setting.