### PR TITLE
Export REST resource types

### DIFF
--- a/src/rest/admin/2022-01/index.ts
+++ b/src/rest/admin/2022-01/index.ts
@@ -79,7 +79,7 @@ import {User} from './user';
 import {Variant} from './variant';
 import {Webhook} from './webhook';
 
-interface RestResources extends ShopifyRestResources {
+export interface RestResources extends ShopifyRestResources {
   AbandonedCheckout: typeof AbandonedCheckout;
   AccessScope: typeof AccessScope;
   AndroidPayKey: typeof AndroidPayKey;

--- a/src/rest/admin/2022-04/index.ts
+++ b/src/rest/admin/2022-04/index.ts
@@ -79,7 +79,7 @@ import {User} from './user';
 import {Variant} from './variant';
 import {Webhook} from './webhook';
 
-interface RestResources extends ShopifyRestResources {
+export interface RestResources extends ShopifyRestResources {
   AbandonedCheckout: typeof AbandonedCheckout;
   AccessScope: typeof AccessScope;
   AndroidPayKey: typeof AndroidPayKey;

--- a/src/rest/admin/2022-07/index.ts
+++ b/src/rest/admin/2022-07/index.ts
@@ -81,7 +81,7 @@ import {User} from './user';
 import {Variant} from './variant';
 import {Webhook} from './webhook';
 
-interface RestResources extends ShopifyRestResources {
+export interface RestResources extends ShopifyRestResources {
   AbandonedCheckout: typeof AbandonedCheckout;
   AccessScope: typeof AccessScope;
   AndroidPayKey: typeof AndroidPayKey;

--- a/src/rest/admin/2022-10/index.ts
+++ b/src/rest/admin/2022-10/index.ts
@@ -81,7 +81,7 @@ import {User} from './user';
 import {Variant} from './variant';
 import {Webhook} from './webhook';
 
-interface RestResources extends ShopifyRestResources {
+export interface RestResources extends ShopifyRestResources {
   AbandonedCheckout: typeof AbandonedCheckout;
   AccessScope: typeof AccessScope;
   AndroidPayKey: typeof AndroidPayKey;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,2 +1,3 @@
 export * from './base-types';
 export * from './session/types';
+export * from './rest/types';


### PR DESCRIPTION
### WHY are these changes introduced?

Some of our REST resource types aren't exported, which makes it harder to work with them than it needs to be!

### WHAT is this pull request doing?

Ensuring we're exporting the types, and updating the auto-generated resource manifests to export their type interface as well.