### PR TITLE
generateLocalHmac uses all query params (excluding hmac)

### DIFF
--- a/src/utils/__tests__/hmac-validator.test.ts
+++ b/src/utils/__tests__/hmac-validator.test.ts
@@ -50,12 +50,14 @@ test('queries without hmac key throw InvalidHmacError', async () => {
   );
 });
 
-test('queries with extra keys are not included in hmac querystring', async () => {
+test('queries with extra keys are included in hmac querystring', async () => {
   shopify.config.apiSecretKey = 'my super secret key';
+  // NB: keys are listed alphabetically
   const queryString =
-    'code=some+code+goes+here&shop=the+shop+URL&state=some+nonce+passed+from+auth&timestamp=a+number+as+a+string';
+    'code=some+code+goes+here&foo=bar&shop=the+shop+URL&state=some+nonce+passed+from+auth&timestamp=a+number+as+a+string';
   const queryObjectWithoutHmac = {
     code: 'some code goes here',
+    foo: 'bar',
     shop: 'the shop URL',
     state: 'some nonce passed from auth',
     timestamp: 'a number as a string',
@@ -65,15 +67,11 @@ test('queries with extra keys are not included in hmac querystring', async () =>
     .update(queryString)
     .digest('hex');
 
-  const testQueryWithExtraParam: AuthQuery = Object.assign(
-    queryObjectWithoutHmac,
-    {
-      hmac: localHmac,
-      'shopify[]': 'callback',
-    },
-  );
+  const queryObjectWithHmac: AuthQuery = Object.assign(queryObjectWithoutHmac, {
+    hmac: localHmac,
+  });
 
-  await expect(
-    shopify.utils.validateHmac(testQueryWithExtraParam),
-  ).resolves.toBe(true);
+  await expect(shopify.utils.validateHmac(queryObjectWithHmac)).resolves.toBe(
+    true,
+  );
 });

--- a/src/utils/hmac-validator.ts
+++ b/src/utils/hmac-validator.ts
@@ -17,21 +17,9 @@ function stringifyQuery(query: AuthQuery): string {
 }
 
 export function createGenerateLocalHmac(config: ConfigInterface) {
-  return async ({
-    code,
-    timestamp,
-    state,
-    shop,
-    host,
-  }: AuthQuery): Promise<string> => {
-    const queryString = stringifyQuery({
-      code,
-      timestamp,
-      state,
-      shop,
-      ...(host && {host}),
-    });
-
+  return async (params: AuthQuery): Promise<string> => {
+    const {hmac, ...query} = params;
+    const queryString = stringifyQuery(query);
     return createSHA256HMAC(config.apiSecretKey, queryString, HashFormat.Hex);
   };
 }


### PR DESCRIPTION
### WHY are these changes introduced?

When Shopify calls the callback route, the HMAC validator only uses `code`,`timestamp`, `state`, `shop`,`host` to check the `hmac` parameter.  If the callback route configured includes other key/value parameters, they're ignored, even though Shopify includes them when callback is returned.

### WHAT is this pull request doing?

The HMAC validator includes all key/value parameters, except for `hmac` itself, when validating the `hmac` value.

Fixes part of #538 