### PR TITLE
Fix redirect URL after OAuth start

### DIFF
--- a/src/auth/oauth/__tests__/oauth.test.ts
+++ b/src/auth/oauth/__tests__/oauth.test.ts
@@ -112,7 +112,7 @@ describe('beginAuth', () => {
 
     expect(response.statusCode).toBe(302);
     expect(response.headers?.Location).toBe(
-      `http://${shop}/admin/oauth/authorize?${expectedQueryString}`,
+      `https://${shop}/admin/oauth/authorize?${expectedQueryString}`,
     );
   });
 

--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -80,9 +80,7 @@ export function createBegin(config: ConfigInterface) {
       statusText: 'Found',
       headers: {
         ...cookies.response.headers!,
-        Location: `${
-          config.hostScheme
-        }://${cleanShop}/admin/oauth/authorize${processedQuery.stringify()}`,
+        Location: `https://${cleanShop}/admin/oauth/authorize${processedQuery.stringify()}`,
       },
     };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "target": "es5",
     "downlevelIteration": true,
     "esModuleInterop": true,
-    "sourceMap": false,
+    "sourceMap": true,
     "noEmitOnError": false,
     "experimentalDecorators": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
### WHY are these changes introduced?

After we begin OAuth, we're currently redirect to `<app scheme>://<shop>`, which is incorrect because the shop if a Shopify address and will always be HTTPS.

### WHAT is this pull request doing?

Changing that URL to always be HTTPS.