### PR TITLE
Default to console calls for logFunction

### DIFF
--- a/adapters/__e2etests__/utils.ts
+++ b/adapters/__e2etests__/utils.ts
@@ -33,4 +33,5 @@ export const config: ConfigInterface = {
   isEmbeddedApp: true,
   isPrivateApp: false,
   sessionStorage: new MemorySessionStorage(),
+  logFunction: () => Promise.resolve(),
 };

--- a/lib/base-types.ts
+++ b/lib/base-types.ts
@@ -36,6 +36,7 @@ export interface ConfigInterface<S extends SessionStorage = SessionStorage>
   sessionStorage: S;
   scopes: AuthScopes;
   isPrivateApp: boolean;
+  logFunction: (severity: LogSeverity, msg: string) => Promise<void>;
 }
 
 export interface Shopify<

--- a/lib/clients/http_client/__tests__/http_client.test.ts
+++ b/lib/clients/http_client/__tests__/http_client.test.ts
@@ -646,7 +646,8 @@ describe('HTTP client', () => {
 
   it('logs deprecation headers to the console when they are present', async () => {
     const client = new HttpClient({domain});
-    console.warn = jest.fn();
+    const warnMock = jest.fn();
+    console.warn = warnMock;
 
     const postBody = {
       query: 'some query',
@@ -682,10 +683,18 @@ describe('HTTP client', () => {
 
     await client.get({path: '/url/path'});
 
-    expect(console.warn).toHaveBeenCalledWith('API Deprecation Notice:', {
-      message: 'This API endpoint has been deprecated',
-      path: 'https://test-shop.myshopify.io/url/path',
-    });
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(warnMock.mock.calls[0][0]).toContain('API Deprecation Notice');
+    expect(warnMock.mock.calls[0][0]).toContain(
+      JSON.stringify(
+        {
+          message: 'This API endpoint has been deprecated',
+          path: 'https://test-shop.myshopify.io/url/path',
+        },
+        null,
+        2,
+      ),
+    );
 
     await client.post({
       path: '/url/path',
@@ -693,11 +702,19 @@ describe('HTTP client', () => {
       data: postBody,
     });
 
-    expect(console.warn).toHaveBeenCalledWith('API Deprecation Notice:', {
-      message: 'This API endpoint has been deprecated',
-      path: 'https://test-shop.myshopify.io/url/path',
-      body: `${JSON.stringify(postBody)}...`,
-    });
+    expect(console.warn).toHaveBeenCalledTimes(2);
+    expect(warnMock.mock.calls[1][0]).toContain('API Deprecation Notice');
+    expect(warnMock.mock.calls[1][0]).toContain(
+      JSON.stringify(
+        {
+          message: 'This API endpoint has been deprecated',
+          path: 'https://test-shop.myshopify.io/url/path',
+          body: `${JSON.stringify(postBody)}...`,
+        },
+        null,
+        2,
+      ),
+    );
   });
 
   it('will wait 5 minutes before logging repeat deprecation alerts', async () => {
@@ -785,7 +802,14 @@ describe('HTTP client', () => {
     expect(logMock.mock.calls[0][0]).toEqual(LogSeverity.Warning);
     expect(logMock.mock.calls[0][1]).toContain('API Deprecation Notice');
     expect(logMock.mock.calls[0][1]).toContain(
-      ': {"message":"This API endpoint has been deprecated","path":"https://test-shop.myshopify.io/url/path"}',
+      JSON.stringify(
+        {
+          message: 'This API endpoint has been deprecated',
+          path: 'https://test-shop.myshopify.io/url/path',
+        },
+        null,
+        2,
+      ),
     );
     expect(logMock.mock.calls[0][1]).toContain(`Stack Trace: Error`);
   });

--- a/lib/clients/http_client/http_client.ts
+++ b/lib/clients/http_client/http_client.ts
@@ -293,15 +293,13 @@ export function createHttpClientClass(
         ) {
           this.LOGGED_DEPRECATIONS[depHash] = Date.now();
 
-          if (config.logFunction) {
-            const stack = new Error().stack;
-            const log = `API Deprecation Notice ${new Date().toLocaleString()} : ${JSON.stringify(
-              deprecation,
-            )}\n    Stack Trace: ${stack}\n`;
-            await config.logFunction(LogSeverity.Warning, log);
-          } else {
-            console.warn('API Deprecation Notice:', deprecation);
-          }
+          console.warn('API Deprecation Notice:', deprecation);
+
+          const stack = new Error().stack;
+          const log = `API Deprecation Notice ${new Date().toLocaleString()} : ${JSON.stringify(
+            deprecation,
+          )}\n    Stack Trace: ${stack}\n`;
+          await config.logFunction(LogSeverity.Warning, log);
         }
       }
 

--- a/lib/clients/http_client/http_client.ts
+++ b/lib/clients/http_client/http_client.ts
@@ -293,11 +293,11 @@ export function createHttpClientClass(
         ) {
           this.LOGGED_DEPRECATIONS[depHash] = Date.now();
 
-          console.warn('API Deprecation Notice:', deprecation);
-
           const stack = new Error().stack;
           const log = `API Deprecation Notice ${new Date().toLocaleString()} : ${JSON.stringify(
             deprecation,
+            null,
+            2,
           )}\n    Stack Trace: ${stack}\n`;
           await config.logFunction(LogSeverity.Warning, log);
         }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -2,7 +2,12 @@ import {abstractCreateDefaultStorage} from '../runtime/session';
 
 import {ShopifyError} from './error';
 import {SessionStorage} from './session/session_storage';
-import {ConfigInterface, ConfigParams, LATEST_API_VERSION} from './base-types';
+import {
+  ConfigInterface,
+  ConfigParams,
+  LATEST_API_VERSION,
+  LogSeverity,
+} from './base-types';
 import {AuthScopes} from './auth/scopes';
 
 export function validateConfig<S extends SessionStorage = SessionStorage>(
@@ -17,7 +22,7 @@ export function validateConfig<S extends SessionStorage = SessionStorage>(
     apiVersion: LATEST_API_VERSION,
     isEmbeddedApp: true,
     isPrivateApp: false,
-    logFunction: () => Promise.resolve(),
+    logFunction: defaultLogFunction,
     // TS hack as sessionStorage is guaranteed to be set
     // to a correct value in `initialize()`.
     sessionStorage: null as unknown as S,
@@ -87,4 +92,21 @@ function notEmpty<T>(value: T): value is NonNullable<T> {
   return typeof value === 'string' || Array.isArray(value)
     ? value.length > 0
     : true;
+}
+
+async function defaultLogFunction(
+  severity: LogSeverity,
+  message: string,
+): Promise<void> {
+  switch (severity) {
+    case LogSeverity.Info:
+      console.log(message);
+      break;
+    case LogSeverity.Warning:
+      console.warn(message);
+      break;
+    case LogSeverity.Error:
+      console.error(message);
+      break;
+  }
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -17,6 +17,7 @@ export function validateConfig<S extends SessionStorage = SessionStorage>(
     apiVersion: LATEST_API_VERSION,
     isEmbeddedApp: true,
     isPrivateApp: false,
+    logFunction: () => Promise.resolve(),
     // TS hack as sessionStorage is guaranteed to be set
     // to a correct value in `initialize()`.
     sessionStorage: null as unknown as S,


### PR DESCRIPTION
### WHY are these changes introduced?

Internally, whenever we called `logFunction`, we had to check if it was set first, which needlessly bloated the code.

### WHAT is this pull request doing?

Default the `logFunction` parameter to a noop function that just resolves a promise, so that we don't have to check before calling it.