### PR TITLE
Fix Webpack 5 bundling error

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "default": "./lib/index.js",
       "require": "./lib/index.js",
-      "types": "./lib/index.d.ts"
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
     },
     "./session-storage/*": {
       "import": "./session-storage/*.js",


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Webpack 5 was throwing an error when bundling
```
Module not found: Error: Default condition should be last one
```

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
One-line to change the order of the `exports` in `package.json` so that webpack stops complaining.

Per https://github.com/bcakmakoglu/revue-draggable/issues/223#issue-1124523112:
> There is a rule in webpack 'enhanced-resolve' causing this error [here](https://github.com/webpack/enhanced-resolve/blob/02d99a2e6852adaf43fecfc3fed14d8d5c8df10b/lib/util/entrypoints.js#L455)
>
> It can be easily fixed by moving "default" entry in package.json to be the last entry

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
