### PR TITLE
Refactoring webhook registration

### DIFF
--- a/adapters/mock/adapter.ts
+++ b/adapters/mock/adapter.ts
@@ -48,6 +48,11 @@ export async function mockFetch({
   });
 
   const next = mockTestRequests.responseList.shift()!;
+  if (!next) {
+    throw new Error(
+      `Missing mock for ${method} to ${url}, have you queued all required responses?`,
+    );
+  }
   if (next instanceof Error) {
     throw next;
   }

--- a/lib/error.ts
+++ b/lib/error.ts
@@ -12,6 +12,7 @@ export class InvalidShopError extends ShopifyError {}
 export class InvalidHostError extends ShopifyError {}
 export class InvalidJwtError extends ShopifyError {}
 export class MissingJwtTokenError extends ShopifyError {}
+export class InvalidDeliveryMethodError extends ShopifyError {}
 
 export class SafeCompareError extends ShopifyError {}
 export class PrivateAppError extends ShopifyError {}

--- a/lib/webhooks/__tests__/handlers.ts
+++ b/lib/webhooks/__tests__/handlers.ts
@@ -8,7 +8,7 @@ import {
 export const HTTP_HANDLER: HttpWebhookHandler = {
   deliveryMethod: DeliveryMethod.Http,
   callbackUrl: '/webhooks',
-  handler: jest.fn(),
+  callback: jest.fn(),
 };
 
 export const EVENT_BRIDGE_HANDLER: EventBridgeWebhookHandler = {

--- a/lib/webhooks/__tests__/handlers.ts
+++ b/lib/webhooks/__tests__/handlers.ts
@@ -1,0 +1,23 @@
+import {
+  DeliveryMethod,
+  HttpWebhookHandler,
+  EventBridgeWebhookHandler,
+  PubSubWebhookHandler,
+} from '../types';
+
+export const HTTP_HANDLER: HttpWebhookHandler = {
+  deliveryMethod: DeliveryMethod.Http,
+  callbackUrl: '/webhooks',
+  handler: jest.fn(),
+};
+
+export const EVENT_BRIDGE_HANDLER: EventBridgeWebhookHandler = {
+  deliveryMethod: DeliveryMethod.EventBridge,
+  arn: 'arn:test',
+};
+
+export const PUB_SUB_HANDLER: PubSubWebhookHandler = {
+  deliveryMethod: DeliveryMethod.PubSub,
+  pubSubProject: 'my-project-id',
+  pubSubTopic: 'my-topic-id',
+};

--- a/lib/webhooks/__tests__/index.test.ts
+++ b/lib/webhooks/__tests__/index.test.ts
@@ -1,0 +1,238 @@
+import request from 'supertest';
+import {StatusCode} from '@shopify/network';
+
+import {
+  getNewTestConfig,
+  queueMockResponse,
+  shopify,
+} from '../../__tests__/test-helper';
+import {HttpWebhookHandler} from '../types';
+import {Shopify} from '../../base-types';
+import {InvalidDeliveryMethodError, InvalidWebhookError} from '../../error';
+import {shopifyApi} from '../..';
+
+import * as mockResponses from './responses';
+import {EVENT_BRIDGE_HANDLER, HTTP_HANDLER, PUB_SUB_HANDLER} from './handlers';
+import {getTestExpressApp, headers, hmac} from './utils';
+
+const REGISTER_PARAMS = {
+  accessToken: 'some token',
+  shop: 'shop1.myshopify.io',
+};
+
+describe('webhooks', () => {
+  it('HTTP handlers that point to the same location are merged', async () => {
+    const topic = 'PRODUCTS_CREATE';
+    const handler1: HttpWebhookHandler = {...HTTP_HANDLER, handler: jest.fn()};
+    const handler2: HttpWebhookHandler = {...HTTP_HANDLER};
+    const handler3: HttpWebhookHandler = {...HTTP_HANDLER, handler: jest.fn()};
+
+    shopify.webhooks.addHandlers({[topic]: handler1});
+
+    queueMockResponse(JSON.stringify(mockResponses.webhookCheckEmptyResponse));
+    queueMockResponse(JSON.stringify(mockResponses.successResponse));
+    await shopify.webhooks.register(REGISTER_PARAMS);
+
+    expect(shopify.webhooks.getTopicsAdded()).toContain('PRODUCTS_CREATE');
+
+    // Add a second handler
+    shopify.webhooks.addHandlers({PRODUCTS_UPDATE: handler2});
+
+    queueMockResponse(JSON.stringify(mockResponses.webhookCheckResponse));
+    queueMockResponse(JSON.stringify(mockResponses.successResponse));
+    await shopify.webhooks.register(REGISTER_PARAMS);
+
+    expect(shopify.webhooks.getTopicsAdded()).toContain('PRODUCTS_UPDATE');
+    expect(shopify.webhooks.getTopicsAdded()).toHaveLength(2);
+
+    // Update the first handler and make sure we still have the two of them
+    const consoleLogMock = jest.spyOn(console, 'log').mockImplementation();
+    const handler3Function = handler3.handler;
+    shopify.webhooks.addHandlers({[topic]: handler3});
+    expect(consoleLogMock).toHaveBeenCalledWith(
+      "Detected multiple handlers for 'PRODUCTS_CREATE', webhooks.process will call them sequentially",
+    );
+    consoleLogMock.mockRestore();
+
+    queueMockResponse(
+      JSON.stringify(mockResponses.webhookCheckMultiHandlerResponse),
+    );
+    await shopify.webhooks.register(REGISTER_PARAMS);
+
+    expect(shopify.webhooks.getTopicsAdded()).toHaveLength(2);
+    expect(shopify.webhooks.getHandlers(topic)).toHaveLength(1);
+
+    // Process an event for this handler to ensure both handlers are triggered
+    const app = getTestExpressApp();
+    app.post('/webhooks', async (req, res) => {
+      await shopify.webhooks.process({
+        rawBody: (req as any).rawBody,
+        rawRequest: req,
+        rawResponse: res,
+      });
+      res.status(StatusCode.Ok).end();
+    });
+
+    const body = JSON.stringify({});
+    await request(app)
+      .post('/webhooks')
+      .set(headers({hmac: hmac(shopify.config.apiSecretKey, body)}))
+      .send(body)
+      .expect(200);
+
+    // Both handlers should have been called
+    expect(handler1.handler).toHaveBeenCalledWith(
+      topic,
+      REGISTER_PARAMS.shop,
+      body,
+    );
+    expect(handler3Function).toHaveBeenCalledWith(
+      topic,
+      REGISTER_PARAMS.shop,
+      body,
+    );
+  });
+
+  it('fails to register multiple eventbrige handlers with the same identifier', async () => {
+    const handler1 = EVENT_BRIDGE_HANDLER;
+    const handler2 = EVENT_BRIDGE_HANDLER;
+
+    shopify.webhooks.addHandlers({PRODUCTS_CREATE: handler1});
+
+    expect(() => {
+      shopify.webhooks.addHandlers({PRODUCTS_CREATE: handler2});
+    }).toThrowError(InvalidDeliveryMethodError);
+  });
+
+  it('fails to register multiple pubsub handlers with the same identifier', async () => {
+    const handler1 = PUB_SUB_HANDLER;
+    const handler2 = PUB_SUB_HANDLER;
+
+    shopify.webhooks.addHandlers({PRODUCTS_CREATE: handler1});
+
+    expect(() => {
+      shopify.webhooks.addHandlers({PRODUCTS_CREATE: handler2});
+    }).toThrowError(InvalidDeliveryMethodError);
+  });
+});
+
+describe('dual webhook registry instances', () => {
+  let shopify2: Shopify;
+  let handler1: HttpWebhookHandler;
+  let handler2: HttpWebhookHandler;
+
+  beforeEach(async () => {
+    handler1 = {...HTTP_HANDLER, handler: jest.fn()};
+    handler2 = {...HTTP_HANDLER, handler: jest.fn()};
+
+    shopify.config.apiSecretKey = 'kitties are cute';
+    shopify.config.isEmbeddedApp = true;
+
+    shopify2 = shopifyApi(getNewTestConfig());
+    shopify2.config.apiSecretKey = 'dogs are cute too';
+    shopify2.config.isEmbeddedApp = true;
+  });
+
+  it('adds different handlers for different topics to each registry', async () => {
+    shopify.webhooks.addHandlers({PRODUCTS: handler1});
+    shopify2.webhooks.addHandlers({PRODUCTS_CREATE: handler2});
+
+    expect(shopify.webhooks.getTopicsAdded()).toStrictEqual(['PRODUCTS']);
+    expect(shopify.webhooks.getHandlers('PRODUCTS')).toStrictEqual([handler1]);
+    expect(shopify.webhooks.getHandlers('PRODUCTS_CREATE')).toEqual([]);
+    expect(shopify2.webhooks.getTopicsAdded()).toStrictEqual([
+      'PRODUCTS_CREATE',
+    ]);
+    expect(shopify2.webhooks.getHandlers('PRODUCTS_CREATE')).toStrictEqual([
+      handler2,
+    ]);
+    expect(shopify2.webhooks.getHandlers('PRODUCTS')).toEqual([]);
+  });
+
+  it('adds different handlers for same topic to each registry', async () => {
+    shopify.webhooks.addHandlers({PRODUCTS: handler1});
+    shopify2.webhooks.addHandlers({PRODUCTS_CREATE: handler2});
+
+    expect(shopify.webhooks.getTopicsAdded()).toStrictEqual(['PRODUCTS']);
+    expect(shopify.webhooks.getHandlers('PRODUCTS')).toStrictEqual([handler1]);
+    expect(shopify2.webhooks.getTopicsAdded()).toStrictEqual([
+      'PRODUCTS_CREATE',
+    ]);
+    expect(shopify2.webhooks.getHandlers('PRODUCTS_CREATE')).toStrictEqual([
+      handler2,
+    ]);
+  });
+
+  const rawBody = '{"foo": "bar"}';
+  const app = getTestExpressApp();
+  app.post('/webhooks', async (req, res) => {
+    let errorThrown = false;
+    let statusCode = StatusCode.Ok;
+    try {
+      await shopify.webhooks.process({
+        rawBody: (req as any).rawBody,
+        rawRequest: req,
+        rawResponse: res,
+      });
+    } catch (error) {
+      errorThrown = true;
+      expect(error).toBeInstanceOf(InvalidWebhookError);
+      statusCode = error.response.statusCode;
+    }
+    res.status(statusCode).json({errorThrown});
+  });
+  app.post('/webhooks2', async (req, res) => {
+    let errorThrown = false;
+    let statusCode = StatusCode.Ok;
+    try {
+      await shopify2.webhooks.process({
+        rawBody: (req as any).rawBody,
+        rawRequest: req,
+        rawResponse: res,
+      });
+    } catch (error) {
+      errorThrown = true;
+      expect(error).toBeInstanceOf(InvalidWebhookError);
+      statusCode = error.response.statusCode;
+    }
+    res.status(statusCode).json({errorThrown});
+  });
+
+  it('can fire handlers from different instances', async () => {
+    shopify.webhooks.addHandlers({PRODUCTS_CREATE: handler1});
+    shopify2.webhooks.addHandlers({PRODUCTS_CREATE: handler2});
+
+    let response = await request(app)
+      .post('/webhooks')
+      .set(
+        headers({
+          topic: 'PRODUCTS_CREATE',
+          hmac: hmac(shopify.config.apiSecretKey, rawBody),
+        }),
+      )
+      .send(rawBody);
+
+    expect(response.status).toEqual(StatusCode.Ok);
+    expect(response.body.errorThrown).toBeFalsy();
+    expect(handler1.handler).toHaveBeenCalled();
+    expect(handler2.handler).not.toHaveBeenCalled();
+
+    (handler1.handler as jest.Mock).mockClear();
+    (handler2.handler as jest.Mock).mockClear();
+
+    response = await request(app)
+      .post('/webhooks2')
+      .set(
+        headers({
+          topic: 'PRODUCTS_CREATE',
+          hmac: hmac(shopify2.config.apiSecretKey, rawBody),
+        }),
+      )
+      .send(rawBody);
+
+    expect(response.status).toEqual(StatusCode.Ok);
+    expect(response.body.errorThrown).toBeFalsy();
+    expect(handler1.handler).not.toHaveBeenCalled();
+    expect(handler2.handler).toHaveBeenCalled();
+  });
+});

--- a/lib/webhooks/__tests__/process.test.ts
+++ b/lib/webhooks/__tests__/process.test.ts
@@ -54,7 +54,7 @@ describe('shopify.webhooks.process', () => {
   });
 
   it('handles the request when topic is already registered', async () => {
-    const handler = {...HTTP_HANDLER, handler: blockingWebhookHandler};
+    const handler = {...HTTP_HANDLER, callback: blockingWebhookHandler};
     shopify.webhooks.addHandlers({PRODUCTS_CREATE: handler});
 
     const response = await request(app)
@@ -68,7 +68,7 @@ describe('shopify.webhooks.process', () => {
   });
 
   it('handles lower case headers', async () => {
-    const handler = {...HTTP_HANDLER, handler: blockingWebhookHandler};
+    const handler = {...HTTP_HANDLER, callback: blockingWebhookHandler};
     shopify.webhooks.addHandlers({PRODUCTS_CREATE: handler});
 
     const response = await request(app)
@@ -87,7 +87,7 @@ describe('shopify.webhooks.process', () => {
   });
 
   it('handles the request and returns Not Found when topic is not registered', async () => {
-    const handler = {...HTTP_HANDLER, handler: blockingWebhookHandler};
+    const handler = {...HTTP_HANDLER, callback: blockingWebhookHandler};
     shopify.webhooks.addHandlers({NONSENSE_TOPIC: handler});
 
     const response = await request(app)
@@ -101,7 +101,7 @@ describe('shopify.webhooks.process', () => {
   });
 
   it('handles the request and returns Unauthorized when hmac does not match', async () => {
-    const handler = {...HTTP_HANDLER, handler: blockingWebhookHandler};
+    const handler = {...HTTP_HANDLER, callback: blockingWebhookHandler};
     shopify.webhooks.addHandlers({PRODUCTS_CREATE: handler});
 
     const response = await request(app)
@@ -115,7 +115,7 @@ describe('shopify.webhooks.process', () => {
   });
 
   it('fails if the given body is empty', async () => {
-    const handler = {...HTTP_HANDLER, handler: blockingWebhookHandler};
+    const handler = {...HTTP_HANDLER, callback: blockingWebhookHandler};
     shopify.webhooks.addHandlers({PRODUCTS_CREATE: handler});
 
     const response = await request(app)
@@ -128,7 +128,7 @@ describe('shopify.webhooks.process', () => {
   });
 
   it('fails if the any of the required headers are missing', async () => {
-    const handler = {...HTTP_HANDLER, handler: blockingWebhookHandler};
+    const handler = {...HTTP_HANDLER, callback: blockingWebhookHandler};
     shopify.webhooks.addHandlers({PRODUCTS_CREATE: handler});
 
     let response = await request(app)
@@ -164,7 +164,7 @@ describe('shopify.webhooks.process', () => {
 
     const handler = {
       ...HTTP_HANDLER,
-      handler: () => {
+      callback: () => {
         throw new Error(errorMessage);
       },
     };

--- a/lib/webhooks/__tests__/process.test.ts
+++ b/lib/webhooks/__tests__/process.test.ts
@@ -1,0 +1,181 @@
+import {StatusCode} from '@shopify/network';
+import request from 'supertest';
+
+import {InvalidWebhookError} from '../../error';
+import {shopify} from '../../__tests__/test-helper';
+
+import {HTTP_HANDLER} from './handlers';
+import {getTestExpressApp, headers, hmac} from './utils';
+
+describe('shopify.webhooks.process', () => {
+  const rawBody = '{"foo": "bar"}';
+
+  const app = getTestExpressApp();
+  app.post('/webhooks', async (req, res) => {
+    let errorThrown = false;
+    let statusCode = StatusCode.Ok;
+    try {
+      await shopify.webhooks.process({
+        rawBody: (req as any).rawBody,
+        rawRequest: req,
+        rawResponse: res,
+      });
+    } catch (error) {
+      errorThrown = true;
+      expect(error).toBeInstanceOf(InvalidWebhookError);
+      statusCode = error.response.statusCode;
+    }
+    res.status(statusCode).json({errorThrown});
+  });
+
+  let blockingWebhookHandlerCalled: boolean;
+  async function blockingWebhookHandler(
+    topic: string,
+    shopDomain: string,
+    body: string,
+  ): Promise<void> {
+    await new Promise((resolve, reject) => {
+      if (!topic || !shopDomain || !body) {
+        reject(new Error('Missing webhook parameters'));
+      }
+
+      setTimeout(() => {
+        blockingWebhookHandlerCalled = true;
+        resolve(true);
+      }, 10);
+    });
+  }
+
+  beforeEach(async () => {
+    shopify.config.apiSecretKey = 'kitties are cute';
+    shopify.config.isEmbeddedApp = true;
+
+    blockingWebhookHandlerCalled = false;
+  });
+
+  it('handles the request when topic is already registered', async () => {
+    const handler = {...HTTP_HANDLER, handler: blockingWebhookHandler};
+    shopify.webhooks.addHandlers({PRODUCTS_CREATE: handler});
+
+    const response = await request(app)
+      .post('/webhooks')
+      .set(headers({hmac: hmac(shopify.config.apiSecretKey, rawBody)}))
+      .send(rawBody)
+      .expect(StatusCode.Ok);
+
+    expect(response.body.errorThrown).toBeFalsy();
+    expect(blockingWebhookHandlerCalled).toBeTruthy();
+  });
+
+  it('handles lower case headers', async () => {
+    const handler = {...HTTP_HANDLER, handler: blockingWebhookHandler};
+    shopify.webhooks.addHandlers({PRODUCTS_CREATE: handler});
+
+    const response = await request(app)
+      .post('/webhooks')
+      .set(
+        headers({
+          hmac: hmac(shopify.config.apiSecretKey, rawBody),
+          lowercase: true,
+        }),
+      )
+      .send(rawBody)
+      .expect(StatusCode.Ok);
+
+    expect(response.body.errorThrown).toBeFalsy();
+    expect(blockingWebhookHandlerCalled).toBeTruthy();
+  });
+
+  it('handles the request and returns Not Found when topic is not registered', async () => {
+    const handler = {...HTTP_HANDLER, handler: blockingWebhookHandler};
+    shopify.webhooks.addHandlers({NONSENSE_TOPIC: handler});
+
+    const response = await request(app)
+      .post('/webhooks')
+      .set(headers({hmac: hmac(shopify.config.apiSecretKey, rawBody)}))
+      .send(rawBody)
+      .expect(StatusCode.NotFound);
+
+    expect(response.body.errorThrown).toBeTruthy();
+    expect(blockingWebhookHandlerCalled).toBeFalsy();
+  });
+
+  it('handles the request and returns Unauthorized when hmac does not match', async () => {
+    const handler = {...HTTP_HANDLER, handler: blockingWebhookHandler};
+    shopify.webhooks.addHandlers({PRODUCTS_CREATE: handler});
+
+    const response = await request(app)
+      .post('/webhooks')
+      .set(headers({hmac: hmac('incorrect secret', rawBody)}))
+      .send(rawBody)
+      .expect(StatusCode.Unauthorized);
+
+    expect(response.body.errorThrown).toBeTruthy();
+    expect(blockingWebhookHandlerCalled).toBeFalsy();
+  });
+
+  it('fails if the given body is empty', async () => {
+    const handler = {...HTTP_HANDLER, handler: blockingWebhookHandler};
+    shopify.webhooks.addHandlers({PRODUCTS_CREATE: handler});
+
+    const response = await request(app)
+      .post('/webhooks')
+      .set(headers())
+      .expect(StatusCode.BadRequest);
+
+    expect(response.body.errorThrown).toBeTruthy();
+    expect(blockingWebhookHandlerCalled).toBeFalsy();
+  });
+
+  it('fails if the any of the required headers are missing', async () => {
+    const handler = {...HTTP_HANDLER, handler: blockingWebhookHandler};
+    shopify.webhooks.addHandlers({PRODUCTS_CREATE: handler});
+
+    let response = await request(app)
+      .post('/webhooks')
+      .set(headers({hmac: ''}))
+      .send(rawBody)
+      .expect(StatusCode.BadRequest);
+
+    expect(response.body.errorThrown).toBeTruthy();
+    expect(blockingWebhookHandlerCalled).toBeFalsy();
+
+    response = await request(app)
+      .post('/webhooks')
+      .set(headers({topic: ''}))
+      .send(rawBody)
+      .expect(StatusCode.BadRequest);
+
+    expect(response.body.errorThrown).toBeTruthy();
+    expect(blockingWebhookHandlerCalled).toBeFalsy();
+
+    response = await request(app)
+      .post('/webhooks')
+      .set(headers({domain: ''}))
+      .send(rawBody)
+      .expect(StatusCode.BadRequest);
+
+    expect(response.body.errorThrown).toBeTruthy();
+    expect(blockingWebhookHandlerCalled).toBeFalsy();
+  });
+
+  it('catches handler errors but still responds', async () => {
+    const errorMessage = 'Oh no something went wrong!';
+
+    const handler = {
+      ...HTTP_HANDLER,
+      handler: () => {
+        throw new Error(errorMessage);
+      },
+    };
+    shopify.webhooks.addHandlers({PRODUCTS_CREATE: handler});
+
+    const response = await request(app)
+      .post('/webhooks')
+      .set(headers({hmac: hmac(shopify.config.apiSecretKey, rawBody)}))
+      .send(rawBody)
+      .expect(StatusCode.InternalServerError);
+
+    expect(response.body.errorThrown).toBeTruthy();
+  });
+});

--- a/lib/webhooks/__tests__/register.test.ts
+++ b/lib/webhooks/__tests__/register.test.ts
@@ -1,0 +1,309 @@
+import {Method, Header} from '@shopify/network';
+
+import {RegisterParams, RegisterReturn, WebhookHandler} from '../types';
+import {gdprTopics, ShopifyHeader} from '../../base-types';
+import {DataType} from '../../clients/types';
+import {queueMockResponse, shopify} from '../../__tests__/test-helper';
+import {mockTestRequests} from '../../../adapters/mock/mock_test_requests';
+import {queryTemplate} from '../query-template';
+import {TEMPLATE_GET_HANDLERS, TEMPLATE_MUTATION} from '../register';
+import {InvalidDeliveryMethodError} from '../../error';
+
+import * as mockResponses from './responses';
+import {MockResponse} from './responses';
+import {EVENT_BRIDGE_HANDLER, HTTP_HANDLER, PUB_SUB_HANDLER} from './handlers';
+
+interface RegisterTestWebhook {
+  topic: string;
+  handler: WebhookHandler;
+  checkMockResponse?: MockResponse;
+  responses?: MockResponse[];
+}
+
+interface RegisterTestResponse {
+  topic: string;
+  registerReturn: RegisterReturn;
+  expectedSuccess?: boolean;
+  responses: MockResponse[];
+}
+
+interface MutationParams {
+  [key: string]: any;
+}
+
+const REGISTER_PARAMS = {
+  accessToken: 'some token',
+  shop: 'shop1.myshopify.io',
+};
+
+describe('shopify.webhooks.register', () => {
+  it('sends a post request to the given shop domain with the webhook data as a GraphQL query in the body and the access token in the headers', async () => {
+    const topic = 'PRODUCTS_CREATE';
+    const handler = HTTP_HANDLER;
+    const responses = [mockResponses.successResponse];
+
+    const registerReturn = await registerWebhook({topic, handler, responses});
+
+    assertWebhookRegistrationRequest('webhookSubscriptionCreate', {
+      topic,
+      callbackUrl: `"https://test_host_name/webhooks"`,
+    });
+    assertRegisterResponse({registerReturn, topic, responses});
+  });
+
+  it('returns a result with success set to false, body set to empty object, when the server doesn’t return a webhookSubscriptionCreate field', async () => {
+    const topic = 'PRODUCTS_CREATE';
+    const handler = HTTP_HANDLER;
+    const responses = [mockResponses.httpFailResponse];
+
+    const registerReturn = await registerWebhook({topic, handler, responses});
+
+    assertWebhookRegistrationRequest('webhookSubscriptionCreate', {
+      topic,
+      callbackUrl: `"https://test_host_name/webhooks"`,
+    });
+    assertRegisterResponse({
+      registerReturn,
+      topic,
+      responses,
+      expectedSuccess: false,
+    });
+  });
+
+  it('sends an eventbridge registration GraphQL query for an eventbridge webhook registration', async () => {
+    const topic = 'PRODUCTS_CREATE';
+    const handler = EVENT_BRIDGE_HANDLER;
+    const responses = [mockResponses.eventBridgeSuccessResponse];
+
+    const registerReturn = await registerWebhook({topic, handler, responses});
+
+    assertWebhookRegistrationRequest('eventBridgeWebhookSubscriptionCreate', {
+      topic,
+      arn: '"arn:test"',
+    });
+    assertRegisterResponse({registerReturn, topic, responses});
+  });
+
+  it('sends a pubsub registration GraphQL query for a pubsub webhook registration', async () => {
+    const topic = 'PRODUCTS_CREATE';
+    const handler = PUB_SUB_HANDLER;
+    const responses = [mockResponses.pubSubSuccessResponse];
+
+    const registerReturn = await registerWebhook({topic, handler, responses});
+
+    assertWebhookRegistrationRequest('pubSubWebhookSubscriptionCreate', {
+      topic,
+      pubSubProject: '"my-project-id"',
+      pubSubTopic: '"my-topic-id"',
+    });
+    assertRegisterResponse({registerReturn, topic, responses});
+  });
+
+  it('deletes and recreates a webhook if the path changes', async () => {
+    const topic = 'PRODUCTS_CREATE';
+    const handler: WebhookHandler = {
+      ...HTTP_HANDLER,
+      callbackUrl: '/webhooks/new',
+    };
+    const responses = [
+      mockResponses.successResponse,
+      mockResponses.successDeleteResponse,
+    ];
+
+    const registerReturn = await registerWebhook({
+      topic,
+      handler,
+      checkMockResponse: mockResponses.webhookCheckResponse,
+      responses,
+    });
+
+    assertWebhookRegistrationRequest('webhookSubscriptionCreate', {
+      topic,
+      callbackUrl: `"https://test_host_name/webhooks/new"`,
+    });
+    assertWebhookRegistrationRequest('webhookSubscriptionDelete', {
+      id: `"${mockResponses.TEST_WEBHOOK_ID}"`,
+    });
+    assertRegisterResponse({registerReturn, topic, responses});
+  });
+
+  it('deletes and recreates a eventbridge webhook if the address changes', async () => {
+    const topic = 'PRODUCTS_CREATE';
+    const handler: WebhookHandler = {
+      ...EVENT_BRIDGE_HANDLER,
+      arn: 'arn:test-new',
+    };
+    const responses = [
+      mockResponses.eventBridgeSuccessResponse,
+      mockResponses.successDeleteResponse,
+    ];
+
+    const registerReturn = await registerWebhook({
+      topic,
+      handler,
+      checkMockResponse: mockResponses.eventBridgeWebhookCheckResponse,
+      responses,
+    });
+
+    assertWebhookRegistrationRequest('eventBridgeWebhookSubscriptionCreate', {
+      topic,
+      arn: `"arn:test-new"`,
+    });
+    assertWebhookRegistrationRequest('webhookSubscriptionDelete', {
+      id: `"${mockResponses.TEST_WEBHOOK_ID}"`,
+    });
+    assertRegisterResponse({registerReturn, topic, responses});
+  });
+
+  it('deletes and recreates a pubsub webhook if the address changes', async () => {
+    const topic = 'PRODUCTS_CREATE';
+    const handler = {...PUB_SUB_HANDLER, pubSubTopic: 'my-new-topic-id'};
+    const responses = [
+      mockResponses.pubSubSuccessResponse,
+      mockResponses.successDeleteResponse,
+    ];
+
+    const registerReturn = await registerWebhook({
+      topic,
+      handler,
+      checkMockResponse: mockResponses.pubSubWebhookCheckResponse,
+      responses,
+    });
+
+    assertWebhookRegistrationRequest('pubSubWebhookSubscriptionCreate', {
+      topic,
+      pubSubProject: '"my-project-id"',
+      pubSubTopic: '"my-new-topic-id"',
+    });
+    assertWebhookRegistrationRequest('webhookSubscriptionDelete', {
+      id: `"${mockResponses.TEST_WEBHOOK_ID}"`,
+    });
+    assertRegisterResponse({registerReturn, topic, responses});
+  });
+
+  it('fully skips registering a webhook if it there are no path changes', async () => {
+    const topic = 'PRODUCTS_CREATE';
+    const handler = HTTP_HANDLER;
+    const responses: MockResponse[] = [];
+
+    const registerReturn = await registerWebhook({
+      topic,
+      handler,
+      checkMockResponse: mockResponses.webhookCheckResponse,
+      responses,
+    });
+
+    expect(registerReturn[topic]).toHaveLength(0);
+  });
+
+  it('fails if given an invalid DeliveryMethod', async () => {
+    const topic = 'PRODUCTS_CREATE';
+    const handler = {...HTTP_HANDLER, deliveryMethod: 'invalid' as any};
+
+    shopify.webhooks.addHandlers({[topic]: handler});
+
+    queueMockResponse(JSON.stringify(mockResponses.webhookCheckEmptyResponse));
+
+    await expect(shopify.webhooks.register(REGISTER_PARAMS)).rejects.toThrow(
+      InvalidDeliveryMethodError,
+    );
+  });
+
+  gdprTopics.forEach((gdprTopic) => {
+    it(`does not send a register for ${gdprTopic}`, async () => {
+      const handler = HTTP_HANDLER;
+
+      shopify.webhooks.addHandlers({[gdprTopic]: handler});
+
+      queueMockResponse(
+        JSON.stringify(mockResponses.webhookCheckEmptyResponse),
+      );
+
+      const response = await shopify.webhooks.register(REGISTER_PARAMS);
+
+      expect(mockTestRequests.requestList).toHaveLength(1);
+      expect(response[gdprTopic]).toHaveLength(0);
+      expect(shopify.webhooks.getTopicsAdded()).toContain(gdprTopic);
+    });
+  });
+});
+
+async function registerWebhook({
+  topic,
+  handler,
+  checkMockResponse = mockResponses.webhookCheckEmptyResponse,
+  responses = [],
+}: RegisterTestWebhook): Promise<RegisterReturn> {
+  shopify.webhooks.addHandlers({[topic]: handler});
+
+  queueMockResponse(JSON.stringify(checkMockResponse));
+  responses.forEach((response) => {
+    queueMockResponse(JSON.stringify(response));
+  });
+
+  const result = await shopify.webhooks.register(REGISTER_PARAMS);
+
+  expect(mockTestRequests.requestList).toHaveLength(responses.length + 1);
+
+  assertWebhookCheckRequest(REGISTER_PARAMS);
+
+  return result;
+}
+
+function assertRegisterResponse({
+  registerReturn,
+  topic,
+  expectedSuccess = true,
+  responses,
+}: RegisterTestResponse) {
+  expect(registerReturn[topic]).not.toHaveLength(0);
+
+  registerReturn[topic].forEach((result, i) => {
+    expect(result.success).toBe(expectedSuccess);
+    expect(result.result).toEqual(responses[i]);
+  });
+}
+
+function createWebhookCheckQuery() {
+  return queryTemplate(TEMPLATE_GET_HANDLERS, {END_CURSOR: 'null'});
+}
+
+function createWebhookQuery(mutationName: string, mutationParams: string) {
+  return queryTemplate(TEMPLATE_MUTATION, {
+    MUTATION_NAME: mutationName,
+    MUTATION_PARAMS: mutationParams,
+  });
+}
+
+function assertWebhookCheckRequest(REGISTER_PARAMS: RegisterParams) {
+  expect({
+    method: Method.Post.toString(),
+    domain: REGISTER_PARAMS.shop,
+    path: `/admin/api/${shopify.config.apiVersion}/graphql.json`,
+    headers: {
+      [Header.ContentType]: DataType.GraphQL.toString(),
+      [ShopifyHeader.AccessToken]: REGISTER_PARAMS.accessToken,
+    },
+    data: createWebhookCheckQuery(),
+  }).toMatchMadeHttpRequest();
+}
+
+function assertWebhookRegistrationRequest(
+  mutationName: string,
+  mutationParams: MutationParams,
+) {
+  const paramsString = Object.entries(mutationParams)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join(',\n      ');
+
+  expect({
+    method: Method.Post.toString(),
+    domain: REGISTER_PARAMS.shop,
+    path: `/admin/api/${shopify.config.apiVersion}/graphql.json`,
+    headers: {
+      [Header.ContentType]: DataType.GraphQL.toString(),
+      [ShopifyHeader.AccessToken]: REGISTER_PARAMS.accessToken,
+    },
+    data: createWebhookQuery(mutationName, paramsString),
+  }).toMatchMadeHttpRequest();
+}

--- a/lib/webhooks/__tests__/register.test.ts
+++ b/lib/webhooks/__tests__/register.test.ts
@@ -70,7 +70,7 @@ describe('shopify.webhooks.register', () => {
     });
   });
 
-  it('sends an eventbridge registration GraphQL query for an eventbridge webhook registration', async () => {
+  it('sends an EventBridge registration GraphQL query for an EventBridge webhook registration', async () => {
     const topic = 'PRODUCTS_CREATE';
     const handler = EVENT_BRIDGE_HANDLER;
     const responses = [mockResponses.eventBridgeSuccessResponse];
@@ -84,7 +84,7 @@ describe('shopify.webhooks.register', () => {
     assertRegisterResponse({registerReturn, topic, responses});
   });
 
-  it('sends a pubsub registration GraphQL query for a pubsub webhook registration', async () => {
+  it('sends a PubSub registration GraphQL query for a PubSub webhook registration', async () => {
     const topic = 'PRODUCTS_CREATE';
     const handler = PUB_SUB_HANDLER;
     const responses = [mockResponses.pubSubSuccessResponse];
@@ -99,7 +99,7 @@ describe('shopify.webhooks.register', () => {
     assertRegisterResponse({registerReturn, topic, responses});
   });
 
-  it('deletes and recreates a webhook if the path changes', async () => {
+  it('creates a new webhook registration if the path changes, then deletes the old one', async () => {
     const topic = 'PRODUCTS_CREATE';
     const handler: WebhookHandler = {
       ...HTTP_HANDLER,
@@ -127,7 +127,7 @@ describe('shopify.webhooks.register', () => {
     assertRegisterResponse({registerReturn, topic, responses});
   });
 
-  it('deletes and recreates a eventbridge webhook if the address changes', async () => {
+  it('creates a new EventBridge webhook registration if the address changes, then deletes the old one', async () => {
     const topic = 'PRODUCTS_CREATE';
     const handler: WebhookHandler = {
       ...EVENT_BRIDGE_HANDLER,
@@ -155,7 +155,7 @@ describe('shopify.webhooks.register', () => {
     assertRegisterResponse({registerReturn, topic, responses});
   });
 
-  it('deletes and recreates a pubsub webhook if the address changes', async () => {
+  it('creates a new PubSub webhook registration if the address changes, then deletes the old one', async () => {
     const topic = 'PRODUCTS_CREATE';
     const handler = {...PUB_SUB_HANDLER, pubSubTopic: 'my-new-topic-id'};
     const responses = [

--- a/lib/webhooks/__tests__/registry.test.ts
+++ b/lib/webhooks/__tests__/registry.test.ts
@@ -20,11 +20,11 @@ describe('shopify.webhooks.addHandlers', () => {
   it('adds two handlers to the webhook registry', async () => {
     handler1 = {
       ...HTTP_HANDLER,
-      handler: jest.fn().mockImplementation(genericWebhookHandler),
+      callback: jest.fn().mockImplementation(genericWebhookHandler),
     };
     handler2 = {
       ...HTTP_HANDLER,
-      handler: jest.fn().mockImplementation(genericWebhookHandler),
+      callback: jest.fn().mockImplementation(genericWebhookHandler),
     };
 
     shopify.webhooks.addHandlers({PRODUCTS_CREATE: handler1});
@@ -38,16 +38,14 @@ describe('shopify.webhooks.addHandlers', () => {
     ]);
   });
 
-  it('merges an HTTP handler', async () => {
-    handler1 = {...HTTP_HANDLER, handler: jest.fn()};
-    handler2 = {...HTTP_HANDLER, handler: jest.fn()};
+  it('allows adding multiple of the same HTTP handler', async () => {
+    handler1 = {...HTTP_HANDLER, callback: jest.fn()};
+    handler2 = {...HTTP_HANDLER, callback: jest.fn()};
 
     const consoleLogMock = jest
       .spyOn(console, 'log')
       .mockImplementation(() => {});
 
-    // handler2.handler will be overwritten when we merge it in
-    const handler2Function = handler2.handler;
     shopify.webhooks.addHandlers({PRODUCTS_CREATE: [handler1, handler2]});
 
     expect(shopify.webhooks.getTopicsAdded()).toHaveLength(1);
@@ -57,14 +55,7 @@ describe('shopify.webhooks.addHandlers', () => {
     consoleLogMock.mockRestore();
 
     const handlers = shopify.webhooks.getHandlers('PRODUCTS_CREATE');
-    await (handlers[0] as HttpWebhookHandler).handler(
-      'PRODUCTS_CREATE',
-      'shop',
-      'body',
-    );
-
-    expect(handler1.handler).toHaveBeenCalled();
-    expect(handler2Function).toHaveBeenCalled();
+    expect(handlers).toEqual([handler1, handler2]);
   });
 
   it('fails if eventbridge handlers point to the same location', async () => {

--- a/lib/webhooks/__tests__/responses.ts
+++ b/lib/webhooks/__tests__/responses.ts
@@ -1,0 +1,197 @@
+export interface MockResponse {
+  [key: string]: unknown;
+}
+
+export const TEST_WEBHOOK_ID = 'gid://shopify/WebhookSubscription/12345';
+
+export const webhookCheckEmptyResponse = {
+  data: {
+    webhookSubscriptions: {
+      edges: [],
+      pageInfo: {
+        endCursor: null,
+        hasNextPage: false,
+      },
+    },
+  },
+};
+
+export const webhookCheckErrorResponse = {
+  errors: [
+    {
+      message:
+        "Argument 'topics' on Field 'webhookSubscriptions' has an invalid value (topic). Expected type '[WebhookSubscriptionTopic!]'.",
+    },
+  ],
+};
+
+export const webhookCheckResponse = {
+  data: {
+    webhookSubscriptions: {
+      edges: [
+        {
+          node: {
+            id: TEST_WEBHOOK_ID,
+            topic: 'PRODUCTS_CREATE',
+            endpoint: {
+              __typename: 'WebhookHttpEndpoint',
+              callbackUrl: 'https://test_host_name/webhooks',
+            },
+          },
+        },
+      ],
+      pageInfo: {
+        endCursor: null,
+        hasNextPage: false,
+      },
+    },
+  },
+};
+
+export const webhookCheckMultiHandlerResponse = {
+  data: {
+    webhookSubscriptions: {
+      edges: [
+        {
+          node: {
+            id: TEST_WEBHOOK_ID,
+            topic: 'PRODUCTS_CREATE',
+            endpoint: {
+              __typename: 'WebhookHttpEndpoint',
+              callbackUrl: 'https://test_host_name/webhooks',
+            },
+          },
+        },
+        {
+          node: {
+            id: `${TEST_WEBHOOK_ID}-2`,
+            topic: 'PRODUCTS_UPDATE',
+            endpoint: {
+              __typename: 'WebhookHttpEndpoint',
+              callbackUrl: 'https://test_host_name/webhooks',
+            },
+          },
+        },
+      ],
+      pageInfo: {
+        endCursor: null,
+        hasNextPage: false,
+      },
+    },
+  },
+};
+
+export const eventBridgeWebhookCheckResponse = {
+  data: {
+    webhookSubscriptions: {
+      edges: [
+        {
+          node: {
+            id: TEST_WEBHOOK_ID,
+            topic: 'PRODUCTS_CREATE',
+            endpoint: {
+              __typename: 'WebhookEventBridgeEndpoint',
+              arn: 'arn:test',
+            },
+          },
+        },
+      ],
+      pageInfo: {
+        endCursor: null,
+        hasNextPage: false,
+      },
+    },
+  },
+};
+
+export const pubSubWebhookCheckResponse = {
+  data: {
+    webhookSubscriptions: {
+      edges: [
+        {
+          node: {
+            id: TEST_WEBHOOK_ID,
+            topic: 'PRODUCTS_CREATE',
+            endpoint: {
+              __typename: 'WebhookPubSubEndpoint',
+              pubSubProject: 'my-project-id',
+              pubSubTopic: 'my-topic-id',
+            },
+          },
+        },
+      ],
+      pageInfo: {
+        endCursor: null,
+        hasNextPage: false,
+      },
+    },
+  },
+};
+
+export const successResponse = {
+  data: {
+    webhookSubscriptionCreate: {
+      userErrors: [],
+    },
+  },
+};
+
+export const eventBridgeSuccessResponse = {
+  data: {
+    eventBridgeWebhookSubscriptionCreate: {
+      userErrors: [],
+    },
+  },
+};
+
+export const pubSubSuccessResponse = {
+  data: {
+    pubSubWebhookSubscriptionCreate: {
+      userErrors: [],
+    },
+  },
+};
+
+export const successUpdateResponse = {
+  data: {
+    webhookSubscriptionUpdate: {
+      userErrors: [],
+    },
+  },
+};
+
+export const eventBridgeSuccessUpdateResponse = {
+  data: {
+    eventBridgeWebhookSubscriptionUpdate: {
+      userErrors: [],
+    },
+  },
+};
+
+export const pubSubSuccessUpdateResponse = {
+  data: {
+    pubSubWebhookSubscriptionUpdate: {
+      userErrors: [],
+    },
+  },
+};
+
+export const successDeleteResponse = {
+  data: {
+    webhookSubscriptionDelete: {
+      userErrors: [],
+    },
+  },
+};
+
+export const failResponse = {
+  data: {},
+};
+
+export const httpFailResponse = {
+  data: {
+    webhookSubscriptionCreate: {
+      userErrors: ['this is an error'],
+    },
+  },
+};

--- a/lib/webhooks/__tests__/utils.ts
+++ b/lib/webhooks/__tests__/utils.ts
@@ -1,0 +1,46 @@
+import crypto from 'crypto';
+
+import express from 'express';
+
+import {ShopifyHeader} from '../../base-types';
+
+export function getTestExpressApp() {
+  const parseRawBody = (req: any, _res: any, next: any) => {
+    req.setEncoding('utf8');
+    req.rawBody = '';
+    req.on('data', (chunk: any) => {
+      req.rawBody += chunk;
+    });
+    req.on('end', () => {
+      next();
+    });
+  };
+
+  const app = express();
+  app.use(parseRawBody);
+  return app;
+}
+
+export function headers({
+  hmac = 'fake',
+  topic = 'PRODUCTS_CREATE',
+  domain = 'shop1.myshopify.io',
+  lowercase = false,
+}: {
+  hmac?: string;
+  topic?: string;
+  domain?: string;
+  lowercase?: boolean;
+} = {}) {
+  return {
+    [lowercase ? ShopifyHeader.Hmac.toLowerCase() : ShopifyHeader.Hmac]: hmac,
+    [lowercase ? ShopifyHeader.Topic.toLowerCase() : ShopifyHeader.Topic]:
+      topic,
+    [lowercase ? ShopifyHeader.Domain.toLowerCase() : ShopifyHeader.Domain]:
+      domain,
+  };
+}
+
+export function hmac(secret: string, body: string) {
+  return crypto.createHmac('sha256', secret).update(body).digest('base64');
+}

--- a/lib/webhooks/index.ts
+++ b/lib/webhooks/index.ts
@@ -1,26 +1,22 @@
 import {ConfigInterface} from '../base-types';
 
-import {HttpWebhookRegistry} from './types';
 import {
-  createAddHttpHandler,
-  createAddHttpHandlers,
-  createGetHttpHandler,
+  createAddHandlers,
   createGetTopicsAdded,
-  createProcess,
-  createRegister,
-  createRegisterAllHttp,
+  createGetHandlers,
+  createRegistry,
 } from './registry';
+import {createRegister} from './register';
+import {createProcess} from './process';
 
 export function shopifyWebhooks(config: ConfigInterface) {
-  const httpWebhookRegistry: HttpWebhookRegistry = {};
+  const webhookRegistry = createRegistry();
 
   return {
-    addHttpHandler: createAddHttpHandler(httpWebhookRegistry),
-    addHttpHandlers: createAddHttpHandlers(httpWebhookRegistry),
-    getHttpHandler: createGetHttpHandler(httpWebhookRegistry),
-    getTopicsAdded: createGetTopicsAdded(httpWebhookRegistry),
-    process: createProcess(config, httpWebhookRegistry),
-    register: createRegister(config),
-    registerAllHttp: createRegisterAllHttp(config, httpWebhookRegistry),
+    addHandlers: createAddHandlers(config, webhookRegistry),
+    getTopicsAdded: createGetTopicsAdded(webhookRegistry),
+    getHandlers: createGetHandlers(webhookRegistry),
+    register: createRegister(config, webhookRegistry),
+    process: createProcess(config, webhookRegistry),
   };
 }

--- a/lib/webhooks/process.ts
+++ b/lib/webhooks/process.ts
@@ -1,0 +1,153 @@
+import {StatusCode} from '@shopify/network';
+
+import {
+  abstractConvertRequest,
+  abstractConvertResponse,
+  AdapterResponse,
+  getHeader,
+  Headers,
+  isOK,
+  NormalizedRequest,
+  NormalizedResponse,
+} from '../../runtime/http';
+import {createSHA256HMAC} from '../../runtime/crypto';
+import {HashFormat} from '../../runtime/crypto/types';
+import {ConfigInterface, ShopifyHeader} from '../base-types';
+import {safeCompare} from '../auth/oauth/safe-compare';
+import * as ShopifyErrors from '../error';
+
+import {WebhookRegistry, WebhookProcessParams, DeliveryMethod} from './types';
+import {topicForStorage} from './registry';
+
+export function createProcess(
+  config: ConfigInterface,
+  webhookRegistry: WebhookRegistry,
+) {
+  return async function process({
+    rawBody,
+    ...adapterArgs
+  }: WebhookProcessParams): Promise<AdapterResponse> {
+    const request: NormalizedRequest = await abstractConvertRequest(
+      adapterArgs,
+    );
+    const response: NormalizedResponse = {
+      statusCode: StatusCode.Ok,
+      statusText: statusTextLookup[StatusCode.Ok],
+      headers: {},
+    };
+
+    const webhookCheck = checkWebhookRequest(rawBody, request.headers);
+    const {webhookOk, hmac, topic, domain} = webhookCheck;
+    let {errorMessage} = webhookCheck;
+
+    if (webhookOk) {
+      const generatedHash = await createSHA256HMAC(
+        config.apiSecretKey,
+        rawBody,
+        HashFormat.Base64,
+      );
+
+      if (safeCompare(generatedHash, hmac)) {
+        const graphqlTopic = topicForStorage(topic);
+        const handlers = webhookRegistry[graphqlTopic] || [];
+
+        let found = false;
+        for (const handler of handlers) {
+          if (handler.deliveryMethod !== DeliveryMethod.Http) {
+            continue;
+          }
+          found = true;
+
+          try {
+            await handler.handler(graphqlTopic, domain, rawBody);
+            response.statusCode = StatusCode.Ok;
+          } catch (error) {
+            response.statusCode = StatusCode.InternalServerError;
+            errorMessage = error.message;
+          }
+        }
+
+        if (!found) {
+          response.statusCode = StatusCode.NotFound;
+          errorMessage = `No HTTP webhooks registered for topic ${topic}`;
+        }
+      } else {
+        response.statusCode = StatusCode.Unauthorized;
+        errorMessage = `Could not validate request for topic ${topic}`;
+      }
+    } else {
+      response.statusCode = StatusCode.BadRequest;
+    }
+
+    response.statusText = statusTextLookup[response.statusCode];
+    const returnResponse = await abstractConvertResponse(response, adapterArgs);
+    if (!isOK(response)) {
+      throw new ShopifyErrors.InvalidWebhookError({
+        message: errorMessage,
+        response: returnResponse,
+      });
+    }
+
+    return Promise.resolve(returnResponse);
+  };
+}
+
+const statusTextLookup: {[key: string]: string} = {
+  [StatusCode.Ok]: 'OK',
+  [StatusCode.BadRequest]: 'Bad Request',
+  [StatusCode.Unauthorized]: 'Unauthorized',
+  [StatusCode.NotFound]: 'Not Found',
+  [StatusCode.InternalServerError]: 'Internal Server Error',
+};
+
+function checkWebhookRequest(
+  rawBody: string,
+  headers: Headers,
+): {
+  webhookOk: boolean;
+  errorMessage: string;
+  hmac: string;
+  topic: string;
+  domain: string;
+} {
+  const retVal = {
+    webhookOk: true,
+    errorMessage: '',
+    hmac: '',
+    topic: '',
+    domain: '',
+  };
+
+  if (rawBody.length) {
+    const hmac = getHeader(headers, ShopifyHeader.Hmac);
+    const topic = getHeader(headers, ShopifyHeader.Topic);
+    const domain = getHeader(headers, ShopifyHeader.Domain);
+
+    const missingHeaders: ShopifyHeader[] = [];
+    if (!hmac) {
+      missingHeaders.push(ShopifyHeader.Hmac);
+    }
+    if (!topic) {
+      missingHeaders.push(ShopifyHeader.Topic);
+    }
+    if (!domain) {
+      missingHeaders.push(ShopifyHeader.Domain);
+    }
+
+    if (missingHeaders.length) {
+      retVal.webhookOk = false;
+      retVal.errorMessage = `Missing one or more of the required HTTP headers to process webhowebhookOks: [${missingHeaders.join(
+        ', ',
+      )}]`;
+    } else {
+      retVal.hmac = hmac as string;
+      retVal.topic = topic as string;
+      retVal.domain = domain as string;
+    }
+  } else {
+    retVal.webhookOk = false;
+    retVal.errorMessage = 'No body was received when processing webhook';
+  }
+
+  return retVal;
+}

--- a/lib/webhooks/query-template.ts
+++ b/lib/webhooks/query-template.ts
@@ -1,0 +1,9 @@
+export function queryTemplate(template: string, params: {[key: string]: any}) {
+  let query = template;
+
+  Object.entries(params).forEach(([key, value]) => {
+    query = query.replace(`{{${key}}}`, value);
+  });
+
+  return query;
+}

--- a/lib/webhooks/register.ts
+++ b/lib/webhooks/register.ts
@@ -1,0 +1,401 @@
+import {createGraphqlClientClass} from '../clients/graphql/graphql_client';
+import {InvalidDeliveryMethodError, ShopifyError} from '../error';
+import {ConfigInterface, gdprTopics} from '../base-types';
+
+import {
+  addHostToCallbackUrl,
+  createGetHandlers,
+  handlerIdentifier,
+} from './registry';
+import {queryTemplate} from './query-template';
+import {
+  WebhookRegistry,
+  RegisterParams,
+  RegisterReturn,
+  WebhookHandler,
+  WebhookCheckResponse,
+  DeliveryMethod,
+  WebhookCheckResponseNode,
+  WebhookOperation,
+} from './types';
+
+interface RunMutationParams {
+  config: ConfigInterface;
+  client: InstanceType<ReturnType<typeof createGraphqlClientClass>>;
+  topic: string;
+  handler: WebhookHandler;
+  operation: WebhookOperation;
+  registerReturn: RegisterReturn;
+}
+
+export function createRegister(
+  config: ConfigInterface,
+  webhookRegistry: WebhookRegistry,
+) {
+  return async function register({
+    accessToken,
+    shop,
+  }: RegisterParams): Promise<RegisterReturn> {
+    const registerReturn: RegisterReturn = Object.keys(webhookRegistry).reduce(
+      (acc: RegisterReturn, topic) => {
+        acc[topic] = [];
+        return acc;
+      },
+      {},
+    );
+
+    const existingHandlers = await getExistingHandlers(
+      config,
+      shop,
+      accessToken,
+    );
+
+    for (const topic in webhookRegistry) {
+      if (!Object.prototype.hasOwnProperty.call(webhookRegistry, topic)) {
+        continue;
+      }
+
+      const handlers = createGetHandlers(webhookRegistry)(topic);
+
+      if (gdprTopics.includes(topic)) {
+        continue;
+      }
+
+      const {toCreate, toUpdate, toDelete} = categorizeHandlers(
+        config,
+        existingHandlers[topic] || [],
+        handlers,
+      );
+
+      const GraphqlClient = createGraphqlClientClass({config});
+      const client = new GraphqlClient({domain: shop, accessToken});
+
+      for (const handler of toCreate) {
+        await runMutation({
+          config,
+          client,
+          topic,
+          handler,
+          operation: WebhookOperation.Create,
+          registerReturn,
+        });
+      }
+
+      for (const handler of toUpdate) {
+        await runMutation({
+          config,
+          client,
+          topic,
+          handler,
+          operation: WebhookOperation.Update,
+          registerReturn,
+        });
+      }
+
+      for (const handler of toDelete) {
+        await runMutation({
+          config,
+          client,
+          topic,
+          handler,
+          operation: WebhookOperation.Delete,
+          registerReturn,
+        });
+      }
+    }
+
+    return registerReturn;
+  };
+}
+
+async function getExistingHandlers(
+  config: ConfigInterface,
+  shop: string,
+  accessToken: string | undefined,
+): Promise<WebhookRegistry> {
+  const GraphqlClient = createGraphqlClientClass({config});
+  const client = new GraphqlClient({domain: shop, accessToken});
+
+  const existingHandlers: WebhookRegistry = {};
+
+  let hasNextPage: boolean;
+  let endCursor: string | null = null;
+  do {
+    const query = buildCheckQuery(endCursor);
+
+    const response = await client.query<WebhookCheckResponse>({
+      data: query,
+    });
+
+    response.body.data.webhookSubscriptions.edges.forEach((edge) => {
+      const handler = buildHandlerFromNode(edge);
+
+      if (!existingHandlers[edge.node.topic]) {
+        existingHandlers[edge.node.topic] = [];
+      }
+
+      existingHandlers[edge.node.topic].push(handler);
+    });
+
+    endCursor = response.body.data.webhookSubscriptions.pageInfo.endCursor;
+    hasNextPage = response.body.data.webhookSubscriptions.pageInfo.hasNextPage;
+  } while (hasNextPage);
+
+  return existingHandlers;
+}
+
+export function buildCheckQuery(endCursor: string | null) {
+  return queryTemplate(TEMPLATE_GET_HANDLERS, {
+    END_CURSOR: JSON.stringify(endCursor),
+  });
+}
+
+function buildHandlerFromNode(edge: WebhookCheckResponseNode): WebhookHandler {
+  const endpoint = edge.node.endpoint;
+
+  let handler: WebhookHandler;
+
+  switch (endpoint.__typename) {
+    case 'WebhookHttpEndpoint':
+      handler = {
+        id: edge.node.id,
+        deliveryMethod: DeliveryMethod.Http,
+        callbackUrl: endpoint.callbackUrl,
+        // This is a dummy for now because we don't really care about it
+        handler: async () => {},
+      };
+      break;
+    case 'WebhookEventBridgeEndpoint':
+      handler = {
+        id: edge.node.id,
+        deliveryMethod: DeliveryMethod.EventBridge,
+        arn: endpoint.arn,
+      };
+      break;
+    case 'WebhookPubSubEndpoint':
+      handler = {
+        id: edge.node.id,
+        deliveryMethod: DeliveryMethod.PubSub,
+        pubSubProject: endpoint.pubSubProject,
+        pubSubTopic: endpoint.pubSubTopic,
+      };
+      break;
+  }
+
+  return handler;
+}
+
+interface HandlersByKey {
+  [key: string]: WebhookHandler;
+}
+
+function categorizeHandlers(
+  config: ConfigInterface,
+  existingHandlers: WebhookHandler[],
+  handlers: WebhookHandler[],
+) {
+  const handlersByKey = handlers.reduce((acc: HandlersByKey, value) => {
+    acc[handlerIdentifier(config, value)] = value;
+    return acc;
+  }, {});
+  const existingHandlersByKey = existingHandlers.reduce(
+    (acc: HandlersByKey, value) => {
+      acc[handlerIdentifier(config, value)] = value;
+      return acc;
+    },
+    {},
+  );
+
+  const toCreate: HandlersByKey = {...handlersByKey};
+  const toUpdate: HandlersByKey = {};
+  const toDelete: HandlersByKey = {};
+  for (const existingKey in existingHandlersByKey) {
+    if (
+      !Object.prototype.hasOwnProperty.call(existingHandlersByKey, existingKey)
+    ) {
+      continue;
+    }
+
+    const existingHandler = existingHandlersByKey[existingKey];
+
+    if (existingKey in handlersByKey) {
+      delete toCreate[existingKey];
+      // For now, there is nothing to update because we only save the identifier fields
+      // toUpdate.push(handler);
+    } else {
+      toDelete[existingKey] = existingHandler;
+    }
+  }
+
+  return {
+    toCreate: Object.values(toCreate),
+    toUpdate: Object.values(toUpdate),
+    toDelete: Object.values(toDelete),
+  };
+}
+
+async function runMutation({
+  config,
+  client,
+  topic,
+  handler,
+  operation,
+  registerReturn,
+}: RunMutationParams): Promise<void> {
+  try {
+    const query = buildMutation(config, topic, handler, operation);
+
+    const result = await client.query({data: query});
+
+    registerReturn[topic].push({
+      deliveryMethod: handler.deliveryMethod,
+      success: isSuccess(result.body, handler, operation),
+      result: result.body,
+    });
+  } catch (error) {
+    if (error instanceof InvalidDeliveryMethodError) {
+      registerReturn[topic].push({
+        deliveryMethod: handler.deliveryMethod,
+        success: false,
+        result: {message: error.message},
+      });
+    } else {
+      throw error;
+    }
+  }
+}
+
+export function buildMutation(
+  config: ConfigInterface,
+  topic: string,
+  handler: WebhookHandler,
+  operation: WebhookOperation,
+): string {
+  const params: {[key: string]: string} = {};
+
+  if (handler.id) {
+    params.id = `"${handler.id}"`;
+  } else {
+    params.topic = topic;
+  }
+
+  if (operation !== WebhookOperation.Delete) {
+    switch (handler.deliveryMethod) {
+      case DeliveryMethod.Http:
+        params.callbackUrl = `"${addHostToCallbackUrl(
+          config,
+          handler.callbackUrl,
+        )}"`;
+        break;
+      case DeliveryMethod.EventBridge:
+        params.arn = `"${handler.arn}"`;
+        break;
+      case DeliveryMethod.PubSub:
+        params.pubSubProject = `"${handler.pubSubProject}"`;
+        params.pubSubTopic = `"${handler.pubSubTopic}"`;
+        break;
+      default:
+        throw new InvalidDeliveryMethodError(
+          `Unrecognized delivery method '${(handler as any).deliveryMethod}'`,
+        );
+    }
+  }
+
+  const paramsString = Object.entries(params)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join(',\n      ');
+
+  return queryTemplate(TEMPLATE_MUTATION, {
+    MUTATION_NAME: getMutationName(handler, operation),
+    MUTATION_PARAMS: paramsString,
+  });
+}
+
+function getMutationName(
+  handler: WebhookHandler,
+  operation: WebhookOperation,
+): string {
+  switch (operation) {
+    case WebhookOperation.Create:
+      return `${getEndpoint(handler)}Create`;
+    case WebhookOperation.Update:
+      return `${getEndpoint(handler)}Update`;
+    case WebhookOperation.Delete:
+      return 'webhookSubscriptionDelete';
+    default:
+      throw new ShopifyError(`Unrecognized operation '${operation}'`);
+  }
+}
+
+function getEndpoint(handler: WebhookHandler): string {
+  switch (handler.deliveryMethod) {
+    case DeliveryMethod.Http:
+      return 'webhookSubscription';
+    case DeliveryMethod.EventBridge:
+      return 'eventBridgeWebhookSubscription';
+    case DeliveryMethod.PubSub:
+      return 'pubSubWebhookSubscription';
+    default:
+      throw new ShopifyError(
+        `Unrecognized delivery method '${(handler as any).deliveryMethod}'`,
+      );
+  }
+}
+
+function isSuccess(
+  result: any,
+  handler: WebhookHandler,
+  operation: WebhookOperation,
+): boolean {
+  const mutationName = getMutationName(handler, operation);
+
+  return Boolean(
+    result.data &&
+      result.data[mutationName] &&
+      result.data[mutationName].userErrors.length === 0,
+  );
+}
+
+export const TEMPLATE_GET_HANDLERS = `{
+  webhookSubscriptions(
+    first: 250,
+    after: {{END_CURSOR}},
+  ) {
+    edges {
+      node {
+        id
+        topic
+        endpoint {
+          __typename
+          ... on WebhookHttpEndpoint {
+            callbackUrl
+          }
+          ... on WebhookEventBridgeEndpoint {
+            arn
+          }
+          ... on WebhookPubSubEndpoint {
+            pubSubProject
+            pubSubTopic
+          }
+        }
+      }
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+  }
+}`;
+
+export const TEMPLATE_MUTATION = `
+  mutation webhookSubscription {
+    {{MUTATION_NAME}}(
+      {{MUTATION_PARAMS}}
+    ) {
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`;

--- a/lib/webhooks/registry.ts
+++ b/lib/webhooks/registry.ts
@@ -1,414 +1,138 @@
-import {StatusCode} from '@shopify/network';
+import {InvalidDeliveryMethodError} from '../error';
+import {ConfigInterface, LogSeverity} from '../base-types';
 
 import {
-  abstractConvertRequest,
-  abstractConvertResponse,
-  AdapterResponse,
-  getHeader,
-  Headers,
-  isOK,
-  NormalizedRequest,
-  NormalizedResponse,
-} from '../../runtime/http';
-import {createSHA256HMAC} from '../../runtime/crypto';
-import {HashFormat} from '../../runtime/crypto/types';
-import {createGraphqlClientClass} from '../clients/graphql/graphql_client';
-import {ConfigInterface, gdprTopics, ShopifyHeader} from '../base-types';
-import {safeCompare} from '../auth/oauth/safe-compare';
-import * as ShopifyErrors from '../error';
-
-import {
-  AddHandlerParams,
-  BuildCheckQueryParams,
-  BuildQueryParams,
+  AddHandlersParams,
   DeliveryMethod,
-  HttpWebhookRegistry,
-  RegisterParams,
-  RegisterReturn,
-  ShortenedRegisterParams,
-  WebhookCheckResponse,
-  WebhookHandlerFunction,
-  WebhookProcessParams,
+  HttpWebhookHandler,
+  WebhookHandler,
+  WebhookRegistry,
 } from './types';
 
-function isSuccess(
-  result: any,
-  deliveryMethod: DeliveryMethod,
-  webhookId?: string,
-): boolean {
-  let endpoint;
-  switch (deliveryMethod) {
-    case DeliveryMethod.Http:
-      endpoint = 'webhookSubscription';
-      break;
-    case DeliveryMethod.EventBridge:
-      endpoint = 'eventBridgeWebhookSubscription';
-      break;
-    case DeliveryMethod.PubSub:
-      endpoint = 'pubSubWebhookSubscription';
-      break;
-    default:
-      return false;
-  }
-  endpoint += webhookId ? 'Update' : 'Create';
-  return Boolean(
-    result.data &&
-      result.data[endpoint] &&
-      result.data[endpoint].webhookSubscription,
-  );
+export function createRegistry(): WebhookRegistry {
+  return {};
 }
 
-export function buildCheckQuery({topic}: BuildCheckQueryParams): string {
-  return `{
-    webhookSubscriptions(first: 1, topics: ${topic}) {
-      edges {
-        node {
-          id
-          endpoint {
-            __typename
-            ... on WebhookHttpEndpoint {
-              callbackUrl
-            }
-            ... on WebhookEventBridgeEndpoint {
-              arn
-            }
-            ... on WebhookPubSubEndpoint {
-              pubSubProject
-              pubSubTopic
-            }
-          }
-        }
-      }
-    }
-  }`;
-}
-
-export function buildQuery({
-  topic,
-  address,
-  deliveryMethod = DeliveryMethod.Http,
-  webhookId,
-}: BuildQueryParams): string {
-  let identifier: string;
-  if (webhookId) {
-    identifier = `id: "${webhookId}"`;
-  } else {
-    identifier = `topic: ${topic}`;
-  }
-
-  let mutationName: string;
-  let webhookSubscriptionArgs: string;
-  let pubSubProject: string;
-  let pubSubTopic: string;
-  switch (deliveryMethod) {
-    case DeliveryMethod.Http:
-      mutationName = webhookId
-        ? 'webhookSubscriptionUpdate'
-        : 'webhookSubscriptionCreate';
-      webhookSubscriptionArgs = `{callbackUrl: "${address}"}`;
-      break;
-    case DeliveryMethod.EventBridge:
-      mutationName = webhookId
-        ? 'eventBridgeWebhookSubscriptionUpdate'
-        : 'eventBridgeWebhookSubscriptionCreate';
-      webhookSubscriptionArgs = `{arn: "${address}"}`;
-      break;
-    case DeliveryMethod.PubSub:
-      mutationName = webhookId
-        ? 'pubSubWebhookSubscriptionUpdate'
-        : 'pubSubWebhookSubscriptionCreate';
-      [pubSubProject, pubSubTopic] = address
-        .replace(/^pubsub:\/\//, '')
-        .split(':');
-      webhookSubscriptionArgs = `{pubSubProject: "${pubSubProject}",
-                                  pubSubTopic: "${pubSubTopic}"}`;
-      break;
-  }
-
-  return `
-    mutation webhookSubscription {
-      ${mutationName}(${identifier}, webhookSubscription: ${webhookSubscriptionArgs}) {
-        userErrors {
-          field
-          message
-        }
-        webhookSubscription {
-          id
-        }
-      }
-    }
-  `;
-}
-
-function topicForStorage(topic: string): string {
+export function topicForStorage(topic: string): string {
   return topic.toUpperCase().replace(/\//g, '_');
 }
 
-export function createAddHttpHandler(httpWebhookRegistry: HttpWebhookRegistry) {
-  return function addHttpHandler(params: AddHandlerParams) {
-    const {topic, handler} = params;
-    httpWebhookRegistry[topicForStorage(topic)] = handler;
-  };
-}
-
-export function createAddHttpHandlers(
-  httpWebhookRegistry: HttpWebhookRegistry,
-) {
-  const addHttpHandler = createAddHttpHandler(httpWebhookRegistry);
-  return function addHttpHandlers(handlers: AddHandlerParams[]): void {
-    handlers.forEach((handlerParam) => addHttpHandler(handlerParam));
-  };
-}
-
-export function createGetHttpHandler(httpWebhookRegistry: HttpWebhookRegistry) {
-  return function getHttpHandler(topic: string): WebhookHandlerFunction | null {
-    return httpWebhookRegistry[topicForStorage(topic)] ?? null;
-  };
-}
-
-export function createGetTopicsAdded(httpWebhookRegistry: HttpWebhookRegistry) {
-  return function getTopicsAdded(): string[] {
-    return Object.keys(httpWebhookRegistry);
-  };
-}
-
-export function createRegister(config: ConfigInterface) {
-  const GraphqlClient = createGraphqlClientClass({config});
-
-  return async function register({
-    path,
-    topic,
-    accessToken,
-    shop,
-    deliveryMethod = DeliveryMethod.Http,
-  }: RegisterParams): Promise<RegisterReturn> {
-    const registerReturn: RegisterReturn = {};
-
-    if (gdprTopics.includes(topic)) {
-      registerReturn[topic] = {
-        success: false,
-        result: {
-          errors: [
-            {
-              message: `GDPR topic '${topic}' cannot be registered here. Please set the appropriate webhook endpoint in the 'GDPR mandatory webhooks' section of 'App setup' in the Partners Dashboard`,
-            },
-          ],
-        },
-      };
-
-      return registerReturn;
-    }
-
-    const client = new GraphqlClient({domain: shop, accessToken});
-    const address =
-      deliveryMethod === DeliveryMethod.Http
-        ? `${config.hostScheme}://${config.hostName}${path}`
-        : path;
-
-    let checkResult;
-    try {
-      checkResult = await client.query<WebhookCheckResponse>({
-        data: buildCheckQuery({topic}),
-      });
-    } catch (error) {
-      const result =
-        error instanceof ShopifyErrors.GraphqlQueryError ? error.response : {};
-      registerReturn[topic] = {success: false, result};
-      return registerReturn;
-    }
-
-    let webhookId: string | undefined;
-    let mustRegister = true;
-
-    if (checkResult.body.data.webhookSubscriptions.edges.length) {
-      const {node} = checkResult.body.data.webhookSubscriptions.edges[0];
-      let endpointAddress = '';
-      if (node.endpoint.__typename === 'WebhookHttpEndpoint') {
-        endpointAddress = node.endpoint.callbackUrl;
-      } else if (node.endpoint.__typename === 'WebhookEventBridgeEndpoint') {
-        endpointAddress = node.endpoint.arn;
-      }
-
-      webhookId = node.id;
-      if (endpointAddress === address) {
-        mustRegister = false;
-      }
-    }
-
-    if (mustRegister) {
-      const result = await client.query({
-        data: buildQuery({topic, address, deliveryMethod, webhookId}),
-      });
-      registerReturn[topic] = {
-        success: isSuccess(result.body, deliveryMethod, webhookId),
-        result: result.body,
-      };
-    } else {
-      registerReturn[topic] = {
-        success: true,
-        result: {},
-      };
-    }
-    return registerReturn;
-  };
-}
-
-export function createRegisterAllHttp(
+export function createAddHandlers(
   config: ConfigInterface,
-  httpWebhookRegistry: HttpWebhookRegistry,
+  webhookRegistry: WebhookRegistry,
 ) {
-  const register = createRegister(config);
-  const getTopicsAdded = createGetTopicsAdded(httpWebhookRegistry);
-  const getHttpHandler = createGetHttpHandler(httpWebhookRegistry);
+  return function addHandlers(handlersToAdd: AddHandlersParams) {
+    Object.entries(handlersToAdd).forEach(([topic, handlers]) => {
+      const topicKey = topicForStorage(topic);
 
-  return async function registerAllHttp({
-    path,
-    accessToken,
-    shop,
-  }: ShortenedRegisterParams): Promise<RegisterReturn> {
-    let registerReturn = {};
-    const topics = getTopicsAdded();
-
-    for (const topic of topics) {
-      const handler = getHttpHandler(topic);
-      if (handler) {
-        const webhook: RegisterParams = {
-          path,
-          topic,
-          accessToken,
-          shop,
-          deliveryMethod: DeliveryMethod.Http,
-        };
-        const returnedRegister = await register(webhook);
-        registerReturn = {...registerReturn, ...returnedRegister};
-      }
-    }
-    return registerReturn;
-  };
-}
-const statusTextLookup: {[key: string]: string} = {
-  [StatusCode.Ok]: 'OK',
-  [StatusCode.BadRequest]: 'Bad Request',
-  [StatusCode.Unauthorized]: 'Unauthorized',
-  [StatusCode.NotFound]: 'Not Found',
-  [StatusCode.InternalServerError]: 'Internal Server Error',
-};
-
-function checkWebhookRequest(
-  rawBody: string,
-  headers: Headers,
-): {
-  webhookOk: boolean;
-  errorMessage: string;
-  hmac: string;
-  topic: string;
-  domain: string;
-} {
-  const retVal = {
-    webhookOk: true,
-    errorMessage: '',
-    hmac: '',
-    topic: '',
-    domain: '',
-  };
-
-  if (rawBody.length) {
-    const hmac = getHeader(headers, ShopifyHeader.Hmac);
-    const topic = getHeader(headers, ShopifyHeader.Topic);
-    const domain = getHeader(headers, ShopifyHeader.Domain);
-
-    const missingHeaders: ShopifyHeader[] = [];
-    if (!hmac) {
-      missingHeaders.push(ShopifyHeader.Hmac);
-    }
-    if (!topic) {
-      missingHeaders.push(ShopifyHeader.Topic);
-    }
-    if (!domain) {
-      missingHeaders.push(ShopifyHeader.Domain);
-    }
-
-    if (missingHeaders.length) {
-      retVal.webhookOk = false;
-      retVal.errorMessage = `Missing one or more of the required HTTP headers to process webhowebhookOks: [${missingHeaders.join(
-        ', ',
-      )}]`;
-    } else {
-      retVal.hmac = hmac as string;
-      retVal.topic = topic as string;
-      retVal.domain = domain as string;
-    }
-  } else {
-    retVal.webhookOk = false;
-    retVal.errorMessage = 'No body was received when processing webhook';
-  }
-
-  return retVal;
-}
-
-export function createProcess(
-  config: ConfigInterface,
-  httpWebhookRegistry: HttpWebhookRegistry,
-) {
-  const getHttpHandler = createGetHttpHandler(httpWebhookRegistry);
-
-  return async function process({
-    rawBody,
-    ...adapterArgs
-  }: WebhookProcessParams): Promise<AdapterResponse> {
-    const request: NormalizedRequest = await abstractConvertRequest(
-      adapterArgs,
-    );
-    const response: NormalizedResponse = {
-      statusCode: StatusCode.Ok,
-      statusText: statusTextLookup[StatusCode.Ok],
-      headers: {},
-    };
-
-    const webhookCheck = checkWebhookRequest(rawBody, request.headers);
-    const {webhookOk, hmac, topic, domain} = webhookCheck;
-    let {errorMessage} = webhookCheck;
-
-    if (webhookOk) {
-      const generatedHash = await createSHA256HMAC(
-        config.apiSecretKey,
-        rawBody,
-        HashFormat.Base64,
-      );
-
-      if (safeCompare(generatedHash, hmac)) {
-        const graphqlTopic = topicForStorage(topic);
-        const handler = getHttpHandler(graphqlTopic);
-
-        if (handler) {
-          try {
-            await handler(graphqlTopic, domain, rawBody);
-            response.statusCode = StatusCode.Ok;
-          } catch (error) {
-            response.statusCode = StatusCode.InternalServerError;
-            errorMessage = error.message;
-          }
-        } else {
-          response.statusCode = StatusCode.NotFound;
-          errorMessage = `No webhook is registered for topic ${topic}`;
+      if (Array.isArray(handlers)) {
+        for (const handler of handlers) {
+          mergeOrAddHandler(config, webhookRegistry, topicKey, handler);
         }
       } else {
-        response.statusCode = StatusCode.Unauthorized;
-        errorMessage = `Could not validate request for topic ${topic}`;
+        mergeOrAddHandler(config, webhookRegistry, topicKey, handlers);
       }
-    } else {
-      response.statusCode = StatusCode.BadRequest;
-    }
-
-    response.statusText = statusTextLookup[response.statusCode];
-    const returnResponse = await abstractConvertResponse(response, adapterArgs);
-    if (!isOK(response)) {
-      throw new ShopifyErrors.InvalidWebhookError({
-        message: errorMessage,
-        response: returnResponse,
-      });
-    }
-
-    return Promise.resolve(returnResponse);
+    });
   };
+}
+
+export function createGetTopicsAdded(webhookRegistry: WebhookRegistry) {
+  return function getTopicsAdded(): string[] {
+    return Object.keys(webhookRegistry);
+  };
+}
+
+export function createGetHandlers(webhookRegistry: WebhookRegistry) {
+  return function getHandlers(topic: string): WebhookHandler[] {
+    return webhookRegistry[topicForStorage(topic)] || [];
+  };
+}
+
+export function handlerIdentifier(
+  config: ConfigInterface,
+  handler: WebhookHandler,
+): string {
+  const prefix = handler.deliveryMethod;
+
+  switch (handler.deliveryMethod) {
+    case DeliveryMethod.Http:
+      return `${prefix}_${addHostToCallbackUrl(config, handler.callbackUrl)}`;
+    case DeliveryMethod.EventBridge:
+      return `${prefix}_${handler.arn}`;
+    case DeliveryMethod.PubSub:
+      return `${prefix}_${handler.pubSubProject}:${handler.pubSubTopic}`;
+    default:
+      throw new InvalidDeliveryMethodError(
+        `Unrecognized delivery method '${(handler as any).deliveryMethod}'`,
+      );
+  }
+}
+
+export function addHostToCallbackUrl(
+  config: ConfigInterface,
+  callbackUrl: string,
+): string {
+  if (callbackUrl.startsWith('/')) {
+    return `${config.hostScheme}://${config.hostName}${callbackUrl}`;
+  } else {
+    return callbackUrl;
+  }
+}
+
+function mergeOrAddHandler(
+  config: ConfigInterface,
+  webhookRegistry: WebhookRegistry,
+  topic: string,
+  handler: WebhookHandler,
+) {
+  if (!(topic in webhookRegistry)) {
+    webhookRegistry[topic] = [handler];
+    return;
+  }
+
+  const identifier = handlerIdentifier(config, handler);
+
+  let merged = false;
+  for (const index in webhookRegistry[topic]) {
+    if (!Object.prototype.hasOwnProperty.call(webhookRegistry[topic], index)) {
+      continue;
+    }
+
+    const existingHandler = webhookRegistry[topic][index];
+    const existingIdentifier = handlerIdentifier(config, existingHandler);
+
+    if (identifier !== existingIdentifier) {
+      continue;
+    }
+
+    // We can merge HTTP handlers because we'll just chain the calls locally. We log this to inform callers that it's
+    // happening.
+    if (handler.deliveryMethod === DeliveryMethod.Http) {
+      config.logFunction(
+        LogSeverity.Info,
+        `Detected multiple handlers for '${topic}', webhooks.process will call them sequentially`,
+      );
+
+      const currentHandler = (existingHandler as HttpWebhookHandler).handler;
+      const newHandler = handler.handler;
+      handler.handler = async (topic, shop, body) => {
+        await currentHandler(topic, shop, body);
+        await newHandler(topic, shop, body);
+      };
+
+      webhookRegistry[topic][index] = handler;
+      merged = true;
+      break;
+    } else {
+      throw new InvalidDeliveryMethodError(
+        `Can only add multiple handlers when deliveryMethod is Http. Invalid handler: ${JSON.stringify(
+          handler,
+        )}`,
+      );
+    }
+  }
+
+  if (!merged) {
+    webhookRegistry[topic].push(handler);
+  }
 }

--- a/lib/webhooks/types.ts
+++ b/lib/webhooks/types.ts
@@ -21,7 +21,7 @@ interface BaseWebhookHandler {
 export interface HttpWebhookHandler extends BaseWebhookHandler {
   deliveryMethod: DeliveryMethod.Http;
   callbackUrl: string;
-  handler: WebhookHandlerFunction;
+  callback: WebhookHandlerFunction;
 }
 
 export interface EventBridgeWebhookHandler extends BaseWebhookHandler {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "prettier": "@shopify/prettier-config",
   "scripts": {
-    "test:all": "jest",
+    "test:all": "yarn pretest:adapters && jest && yarn clean",
     "test": "jest --selectProjects library",
     "pretest:adapters": "yarn build && yarn rollup -c adapters/__e2etests__/rollup.test-cf-worker-app.config.js",
     "test:adapters": "jest --selectProjects adapters:mock adapters:node adapters:cf-worker",


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, our implementation of webhooks only allows a single handler to be added for a topic, which doesn't match the actual API behaviour, that's happy to accept multiple handlers.

### WHAT is this pull request doing?

Massively refactoring the input format for webhooks (though not really changing the inner logic too much), so that multiple handlers can be added to the webhook registry.

Instead of looking for each handler individually, we register all webhooks through a single `shopify.webhooks.register()` call that will:
1. Fetch all current handlers
2. Compare them with the currently configured ones by looking at `topic`, `delivery method` and whatever address it points to
3. Insert, update, and delete handlers as required

As I was making these changes, the 1000-line long webhooks test file was super confusing, so I broke it up into multiple files which are hopefully easier to understand.