### PR TITLE
Add optional webhook handler fields

### DIFF
--- a/lib/webhooks/__tests__/index.test.ts
+++ b/lib/webhooks/__tests__/index.test.ts
@@ -30,6 +30,7 @@ describe('webhooks', () => {
     shopify.webhooks.addHandlers({[topic]: handler1});
 
     queueMockResponse(JSON.stringify(mockResponses.webhookCheckEmptyResponse));
+    // Create PRODUCTS_CREATE
     queueMockResponse(JSON.stringify(mockResponses.successResponse));
     await shopify.webhooks.register(REGISTER_PARAMS);
 
@@ -39,6 +40,7 @@ describe('webhooks', () => {
     shopify.webhooks.addHandlers({PRODUCTS_UPDATE: handler2});
 
     queueMockResponse(JSON.stringify(mockResponses.webhookCheckResponse));
+    // Create PRODUCTS_UPDATE
     queueMockResponse(JSON.stringify(mockResponses.successResponse));
     await shopify.webhooks.register(REGISTER_PARAMS);
 

--- a/lib/webhooks/__tests__/index.test.ts
+++ b/lib/webhooks/__tests__/index.test.ts
@@ -30,7 +30,6 @@ describe('webhooks', () => {
     shopify.webhooks.addHandlers({[topic]: handler1});
 
     queueMockResponse(JSON.stringify(mockResponses.webhookCheckEmptyResponse));
-    // Create PRODUCTS_CREATE
     queueMockResponse(JSON.stringify(mockResponses.successResponse));
     await shopify.webhooks.register(REGISTER_PARAMS);
 
@@ -40,7 +39,6 @@ describe('webhooks', () => {
     shopify.webhooks.addHandlers({PRODUCTS_UPDATE: handler2});
 
     queueMockResponse(JSON.stringify(mockResponses.webhookCheckResponse));
-    // Create PRODUCTS_UPDATE
     queueMockResponse(JSON.stringify(mockResponses.successResponse));
     await shopify.webhooks.register(REGISTER_PARAMS);
 

--- a/lib/webhooks/__tests__/register.test.ts
+++ b/lib/webhooks/__tests__/register.test.ts
@@ -103,7 +103,7 @@ describe('shopify.webhooks.register', () => {
     const topic = 'PRODUCTS_CREATE';
     const handler: WebhookHandler = {
       ...HTTP_HANDLER,
-      includeFields: ['id', 'title'],
+      privateMetafieldNamespaces: ['new-private-namespace'],
     };
     const responses = [mockResponses.successUpdateResponse];
 
@@ -117,7 +117,7 @@ describe('shopify.webhooks.register', () => {
     assertWebhookRegistrationRequest('webhookSubscriptionUpdate', {
       id: `"${mockResponses.TEST_WEBHOOK_ID}"`,
       callbackUrl: `"https://test_host_name/webhooks"`,
-      includeFields: '["id","title"]',
+      privateMetafieldNamespaces: '["new-private-namespace"]',
     });
     assertRegisterResponse({registerReturn, topic, responses});
   });
@@ -149,7 +149,7 @@ describe('shopify.webhooks.register', () => {
     const topic = 'PRODUCTS_CREATE';
     const handler: WebhookHandler = {
       ...PUB_SUB_HANDLER,
-      privateMetafieldNamespaces: ['new-private-namespace'],
+      includeFields: ['id', 'title'],
     };
     const responses = [mockResponses.pubSubSuccessUpdateResponse];
 
@@ -164,7 +164,7 @@ describe('shopify.webhooks.register', () => {
       id: `"${mockResponses.TEST_WEBHOOK_ID}"`,
       pubSubProject: '"my-project-id"',
       pubSubTopic: '"my-topic-id"',
-      privateMetafieldNamespaces: '["new-private-namespace"]',
+      includeFields: '["id","title"]',
     });
     assertRegisterResponse({registerReturn, topic, responses});
   });

--- a/lib/webhooks/register.ts
+++ b/lib/webhooks/register.ts
@@ -146,6 +146,9 @@ function buildHandlerFromNode(edge: WebhookCheckResponseNode): WebhookHandler {
         // This is a dummy for now because we don't really care about it
         callback: async () => {},
       };
+
+      // This field only applies to HTTP webhooks
+      handler.privateMetafieldNamespaces?.sort();
       break;
     case 'WebhookEventBridgeEndpoint':
       handler = {
@@ -170,9 +173,6 @@ function buildHandlerFromNode(edge: WebhookCheckResponseNode): WebhookHandler {
   // Sort the array fields to make them cheaper to compare later on
   handler.includeFields?.sort();
   handler.metafieldNamespaces?.sort();
-  if (handler.deliveryMethod === DeliveryMethod.Http) {
-    handler.privateMetafieldNamespaces?.sort();
-  }
 
   return handler;
 }
@@ -298,7 +298,7 @@ function arraysEqual(arr1: any[], arr2: any[]): boolean {
     return false;
   }
 
-  for (let i = 0, len = arr1.length; i < len; i++) {
+  for (let i = 0; i < arr1.length; i++) {
     if (arr1[i] !== arr2[i]) {
       return false;
     }

--- a/lib/webhooks/registry.ts
+++ b/lib/webhooks/registry.ts
@@ -84,6 +84,12 @@ function mergeOrAddHandler(
   topic: string,
   handler: WebhookHandler,
 ) {
+  handler.includeFields?.sort();
+  handler.metafieldNamespaces?.sort();
+  if (handler.deliveryMethod === DeliveryMethod.Http) {
+    handler.privateMetafieldNamespaces?.sort();
+  }
+
   if (!(topic in webhookRegistry)) {
     webhookRegistry[topic] = [handler];
     return;

--- a/lib/webhooks/types.ts
+++ b/lib/webhooks/types.ts
@@ -16,6 +16,9 @@ export type WebhookHandlerFunction = (
 
 interface BaseWebhookHandler {
   id?: string;
+  includeFields?: string[];
+  metafieldNamespaces?: string[];
+  privateMetafieldNamespaces?: string[];
 }
 
 export interface HttpWebhookHandler extends BaseWebhookHandler {
@@ -87,6 +90,9 @@ export interface WebhookCheckResponseNode<
   node: {
     id: string;
     topic: string;
+    includeFields: string[];
+    metafieldNamespaces: string[];
+    privateMetafieldNamespaces: string[];
   } & T;
 }
 

--- a/lib/webhooks/types.ts
+++ b/lib/webhooks/types.ts
@@ -18,11 +18,11 @@ interface BaseWebhookHandler {
   id?: string;
   includeFields?: string[];
   metafieldNamespaces?: string[];
-  privateMetafieldNamespaces?: string[];
 }
 
 export interface HttpWebhookHandler extends BaseWebhookHandler {
   deliveryMethod: DeliveryMethod.Http;
+  privateMetafieldNamespaces?: string[];
   callbackUrl: string;
   callback: WebhookHandlerFunction;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, there are some fields in the webhook mutations that we don't support in the library.

### WHAT is this pull request doing?

Adding support for those fields, and enabling the logic for updating existing handlers now that there are fields that might change. We still check that the values themselves haven't changed,