### PR TITLE
[Fix] Remove $ to enhance commands copy

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -29,9 +29,9 @@ $ yarn add --dev dotenv typescript @types/node
   <summary>Express</summary>
 
 ```shell
-$ yarn init -y
-$ yarn add @shopify/shopify-api express
-$ yarn add --dev dotenv typescript @types/express
+yarn init -y
+yarn add @shopify/shopify-api express
+yarn add --dev dotenv typescript @types/express
 ```
 
 </details>


### PR DESCRIPTION
Removing $ makes it possible to copy the command more easily.
