### PR TITLE
Restrict packaged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,5 +126,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^4.6.3"
-  }
+  },
+  "files": ["**/*.d.ts", "**/*.d.ts.map", "**/*.js", "**/*.js.map", "!bundle/*", "!node_modules"]
 }


### PR DESCRIPTION
We're currently exporting more files than necessary because we're not properly restricting what goes into the package.

This PR fixes that by only exporting the actual code files to be used by apps.