### PR TITLE
Delete fully removed webhook topics

### DIFF
--- a/lib/webhooks/types.ts
+++ b/lib/webhooks/types.ts
@@ -1,4 +1,5 @@
 import {AdapterArgs} from '../../runtime';
+import {Session} from '../session/session';
 
 import type {shopifyWebhooks} from '.';
 
@@ -55,8 +56,7 @@ export enum WebhookOperation {
 }
 
 export interface RegisterParams {
-  shop: string;
-  accessToken: string;
+  session: Session;
 }
 
 export interface RegisterResult {


### PR DESCRIPTION
### WHY are these changes introduced?

With the new webhook registration model, we're now deleting handlers that are no longer being used. However, we were not properly handling topics that were fully removed from the registry - i.e. they exist in Shopify, but not in the app's configs.

### WHAT is this pull request doing?

Going over leftover topics, and deleting any handlers we have for them.

As a bonus, I'm refactoring `webhooks.register` to take in a session object rather than the session fields we'll need.