### PR TITLE
[Chore] Remove log function old setting

### DIFF
--- a/lib/base-types.ts
+++ b/lib/base-types.ts
@@ -15,7 +15,6 @@ export interface ConfigParams<T extends ShopifyRestResources = any> {
   apiVersion: ApiVersion;
   isEmbeddedApp: boolean;
   isPrivateApp?: boolean;
-  logFunction?: (severity: LogSeverity, msg: string) => Promise<void>;
   userAgentPrefix?: string;
   privateAppStorefrontAccessToken?: string;
   customShopDomains?: (RegExp | string)[];


### PR DESCRIPTION
This is simply removing the unused `logFunction` from the settings type (it's been replaced with `logger.log`).