### PR TITLE
Fix auth and utils docs to reflect updated v6 library methods and exports

### DIFF
--- a/docs/usage/oauth.md
+++ b/docs/usage/oauth.md
@@ -102,7 +102,7 @@ This method takes an object with the following properties:
 
 | Parameter     | Type              |      Required?       | Default Value | Notes                                                                                          |
 | ------------- | ----------------- | :------------------: | :-----------: | ---------------------------------------------------------------------------------------------- |
-| `isOnline`    | `bool`            |         Yes          |       -       | `true` if the session is online and `false` otherwise. Must match the value from `auth.begin`. |
+| `isOnline`    | `boolean`         |         Yes          |       -       | `true` if the session is online and `false` otherwise. Must match the value from `auth.begin`. |
 | `rawRequest`  | `AdapterRequest`  |         Yes          |       -       | The HTTP Request object used by your runtime.                                                  |
 | `rawResponse` | `AdapterResponse` | _Depends on runtime_ |       -       | The HTTP Response object used by your runtime. Required for Node.js.                           |
 
@@ -115,7 +115,7 @@ It will save a new session using your configured `sessionStorage`, and return an
 
 ## Using sessions
 
-Once you set up both of the above endpoints, you can navigate to `{your ngrok address}/auth` in your browser to begin OAuth. When it completes, you will have a Shopify session that enables you to make requests to the Admin API, for instance [the REST Admin API client](./rest.md).
+Once you set up both of the above endpoints, you can navigate to `<hostname>/auth` in your browser to begin OAuth, replacing `<hostname>` with either the tunnel url (e.g. ngrok, Cloudflare, etc.), or `localhost`, or the url to the running instance on a cloud platform, depending on how you are running your application. When it completes, you will have a Shopify session that enables you to make requests to the Admin API, for instance [the REST Admin API client](./rest.md).
 
 ### Loading a session while handling a request
 
@@ -148,7 +148,10 @@ Learn more about [making authenticated requests](https://shopify.dev/apps/auth/o
 
 If your app needs to access the API while not handling a direct request, for example in a background job, you can use `shopify.session.getOfflineId` to generate an offline session id for the given shop that can then be used to load an offline access token for your script.
 
-**Note**: this method **_does not_** perform any validation on the `shop` parameter. You should **_never_** read the shop from user inputs or URLs.
+**Note 1**: this method **_does not_** perform any validation on the `shop` parameter. You should **_never_** read the shop from user inputs or URLs.
+
+**Note 2**: obtaining and storing an offline session is performed by going through the OAuth process described above, i.e., using the [start endpoint](#start-endpoint) and [callback endpoint](#callback-endpoint), with the `isOnline` parameter set to `false` for both `shopify.auth.begin()` and `shopify.auth.callback()`.
+
 
 ```ts
 const offlineSessionId = await shopify.session.getOfflineId({

--- a/docs/usage/oauth.md
+++ b/docs/usage/oauth.md
@@ -176,4 +176,57 @@ if (!shopify.config.scopes.equals(session.scope)) {
 
 This is useful if you have a middleware or pre-request check in your app to ensure that the session is still valid.
 
+## Auth-related utility methods
+
+### Get the application URL for embedded apps using `getEmbeddedAppUrl`
+
+If you need to redirect a request to your embedded app URL you can use `getEmbeddedAppUrl`
+
+```ts
+const redirectURL = shopify.auth.getEmbeddedAppUrl({
+  rawRequest: req,
+  rawResponse: res,
+});
+res.redirect(redirectURL);
+```
+
+Using this utility ensures that embedded app URL is properly constructed and brings the merchant to the right place. It is more reliable than using the shop param.
+
+This utility relies on the host query param being a Base 64 encoded string. All requests from Shopify should include this param in the correct format.
+
+### Safely compare two strings, string arrays, number arrays, or simple JS objects with `safeCompare`
+
+`safeCompare` takes a pair of arguments of any of the following types and returns true if they are identical, both in term of type and content.
+
+```ts
+string
+{[key: string]: string}
+string[]
+number[]
+```
+
+```ts
+const stringArray1 = ['alice', 'bob', 'charlie'];
+const stringArray2 = ['alice', 'bob', 'charlie'];
+
+const stringArrayResult = shopify.auth.safeCompare(stringArray1, stringArray2);  // true
+
+const array1 = ['one fish', 'two fish'];
+const array2 = ['red fish', 'blue fish'];
+const arrayResult = shopify.auth.safeCompare(array1, array2); // false
+
+const arg1 = 'hello';
+const arg2 = ['world'];
+
+const argResult = shopify.auth.safeCompare(arg1, arg2); // throws SafeCompareError due to argument type mismatch
+```
+
+### Generate a cryptographically random string of digits with `nonce`
+
+`nonce` generates a string of 15 characters that are cryptographically random, suitable for short-lived values in cookies to aid validation of requests/responses.
+
+```ts
+const state = shopify.auth.nonce();
+```
+
 [Back to guide index](../../README.md#features)

--- a/docs/usage/utils.md
+++ b/docs/usage/utils.md
@@ -1,30 +1,41 @@
 # utils
 
-## Get the application URL for embedded apps using `getEmbeddedAppUrl`
-
-If you need to redirect a request to your embedded app URL you can use `getEmbeddedAppUrl`
-
-```ts
-const redirectURL = Shopify.Utils.getEmbeddedAppUrl(request);
-res.redirect(redirectURL);
-```
-
-Using this utility ensures that embedded app URL is properly constructed and brings the merchant to the right place. It is more reliable than using the shop param.
-
-This utility relies on the host query param being a Base 64 encoded string. All requests from Shopify should include this param in the correct format.
-
 ## Sanitize a Shopify shop domain and host address
 
 When receiving input from users, like in URL query arguments, you should always make sure to sanitize that data.
 To make it easier to do that, this library provides the following methods:
 
 ```ts
-const shop = Shopify.Utils.sanitizeShop(req.query.shop, true);
-const host = Shopify.Utils.sanitizeHost(req.query.host, true);
+const shop = shopify.utils.sanitizeShop(req.query.shop, true);
+const host = shopify.utils.sanitizeHost(req.query.host, true);
 ```
 
 Both of these return the string itself if it's valid, or `null` otherwise.
 You can also optionally set the method to throw an exception if the validation fails.
 If you're using custom shop domains for testing, you can add them to the `config.customShopDomains` setting.
+
+## Check if a query string from Shopify is valid with `validateHmac`
+
+For query strings received from Shopify that are expected to contain a hash-based message authentication code (HMAC) parameter, the `validateHmac` method can be used to perform that validation to determine the query string's integrity.
+
+```ts
+const isValid = await shopify.utils.validateHmac(req.query);
+```
+
+## Check API version compatibility with `versionCompatible`
+
+If you need to determine if API version used in the library configuration is equal or newer than a given API version (to programmatically determine if certain versioned Shopify API capabilities are available, for example), the `shopify.utils.versionCompatible()` method can be used.
+
+```ts
+const shopify = shopifyApi({
+  apiVersion: ApiVersion.July22,
+  ...
+});
+
+if (shopify.utils.versionCompatible(ApiVersion.January22)) {
+  // true in this example, as ApiVersion.July22 is newer than ApiVersion.January22
+  ...
+}
+```
 
 [Back to guide index](../../README.md#features)


### PR DESCRIPTION
### WHAT is this pull request doing?

- `getEmbeddedAppUrl` used to be in `Shopify.Utils`, now in `shopify.auth`- update docs to reflect the change.
- Add documentation for `nonce` and `safeCompare` in `shopify.auth`
- Add documentation for `validateHmac` and `versionCompatible` in `shopify.utils`
