### PR TITLE
[WIP] [Feature] Pass webhook id to handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- [Minor] Pass webhook id to handlers
+
 ## [5.2.0] - 2022-10-04
 
 - Added support for the `2022-10` API version [#535](https://github.com/Shopify/shopify-api-node/pull/535)

--- a/src/base-types.ts
+++ b/src/base-types.ts
@@ -36,5 +36,5 @@ export enum ShopifyHeader {
   Hmac = 'X-Shopify-Hmac-Sha256',
   Topic = 'X-Shopify-Topic',
   Domain = 'X-Shopify-Shop-Domain',
-  WebhookId = 'X-Shopify-Webhook-Id'
+  WebhookId = 'X-Shopify-Webhook-Id',
 }

--- a/src/base-types.ts
+++ b/src/base-types.ts
@@ -36,4 +36,5 @@ export enum ShopifyHeader {
   Hmac = 'X-Shopify-Hmac-Sha256',
   Topic = 'X-Shopify-Topic',
   Domain = 'X-Shopify-Shop-Domain',
+  WebhookId = 'X-Shopify-Webhook-Id'
 }

--- a/src/webhooks/__tests__/registry.test.ts
+++ b/src/webhooks/__tests__/registry.test.ts
@@ -46,7 +46,7 @@ async function genericWebhookHandler(
   topic: string,
   shopDomain: string,
   body: string,
-  webhookId: string,
+  webhookId?: string,
 ): Promise<void> {
   if (!topic || !shopDomain || !body || !webhookId) {
     throw new Error('Missing webhook parameters');
@@ -703,11 +703,13 @@ function headers({
   hmac = 'fake',
   topic = 'products',
   domain = 'shop1.myshopify.io',
+  webhookId = 'b54557e4-bdd9-4b37-8a5f-bf7d70bcd043',
   lowercase = false,
 }: {
   hmac?: string;
   topic?: string;
   domain?: string;
+  webhookId?: string;
   lowercase?: boolean;
 } = {}) {
   return {
@@ -716,6 +718,9 @@ function headers({
       topic,
     [lowercase ? ShopifyHeader.Domain.toLowerCase() : ShopifyHeader.Domain]:
       domain,
+    [lowercase
+      ? ShopifyHeader.WebhookId.toLowerCase()
+      : ShopifyHeader.WebhookId]: webhookId,
   };
 }
 

--- a/src/webhooks/__tests__/registry.test.ts
+++ b/src/webhooks/__tests__/registry.test.ts
@@ -46,8 +46,9 @@ async function genericWebhookHandler(
   topic: string,
   shopDomain: string,
   body: string,
+  webhookId: string,
 ): Promise<void> {
-  if (!topic || !shopDomain || !body) {
+  if (!topic || !shopDomain || !body || !webhookId) {
     throw new Error('Missing webhook parameters');
   }
 }

--- a/src/webhooks/registry.ts
+++ b/src/webhooks/registry.ts
@@ -360,6 +360,7 @@ const WebhooksRegistry: RegistryInterface = {
         let hmac: string | string[] | undefined;
         let topic: string | string[] | undefined;
         let domain: string | string[] | undefined;
+        let webhookId: string | string[] | undefined;
         Object.entries(request.headers).map(([header, value]) => {
           switch (header.toLowerCase()) {
             case ShopifyHeader.Hmac.toLowerCase():
@@ -370,6 +371,9 @@ const WebhooksRegistry: RegistryInterface = {
               break;
             case ShopifyHeader.Domain.toLowerCase():
               domain = value;
+              break;
+            case ShopifyHeader.WebhookId.toLowerCase():
+              webhookId = value;
               break;
           }
         });
@@ -383,6 +387,9 @@ const WebhooksRegistry: RegistryInterface = {
         }
         if (!domain) {
           missingHeaders.push(ShopifyHeader.Domain);
+        }
+        if (!webhookId) {
+          missingHeaders.push(ShopifyHeader.WebhookId);
         }
 
         if (missingHeaders.length) {
@@ -417,6 +424,8 @@ const WebhooksRegistry: RegistryInterface = {
                 graphqlTopic,
                 domain as string,
                 reqBody,
+                webhookId as string,
+
               );
               statusCode = StatusCode.Ok;
             } catch (error) {

--- a/src/webhooks/registry.ts
+++ b/src/webhooks/registry.ts
@@ -425,7 +425,6 @@ const WebhooksRegistry: RegistryInterface = {
                 domain as string,
                 reqBody,
                 webhookId as string,
-
               );
               statusCode = StatusCode.Ok;
             } catch (error) {

--- a/src/webhooks/types.ts
+++ b/src/webhooks/types.ts
@@ -8,6 +8,7 @@ type WebhookHandlerFunction = (
   topic: string,
   shop_domain: string,
   body: string,
+  webhookId: string,
 ) => Promise<void>;
 
 export interface RegisterOptions {

--- a/src/webhooks/types.ts
+++ b/src/webhooks/types.ts
@@ -8,7 +8,7 @@ type WebhookHandlerFunction = (
   topic: string,
   shop_domain: string,
   body: string,
-  webhookId: string,
+  webhookId?: string | undefined,
 ) => Promise<void>;
 
 export interface RegisterOptions {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #370 

### WHAT is this pull request doing?

Grabs the webhook id from the 'X-Shopify-Webhook-Id' header and passes it to the webhook handlers.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
