### PR TITLE
Add deprecation logger method

### DIFF
--- a/lib/__tests__/test-helper.ts
+++ b/lib/__tests__/test-helper.ts
@@ -14,6 +14,7 @@ import {
 } from '../../runtime/http';
 import {Session} from '../session/session';
 import {RequestReturn} from '../clients/http_client/types';
+import {SHOPIFY_API_LIBRARY_VERSION} from '../version';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -21,6 +22,7 @@ declare global {
     interface Matchers<R> {
       toBeWithinSecondsOf(compareDate: number, seconds: number): R;
       toMatchMadeHttpRequest(): R;
+      toBeWithinDeprecationSchedule(): R;
     }
   }
 }
@@ -54,6 +56,14 @@ export function getNewTestConfig(): ConfigParams {
 beforeEach(() => {
   testConfig = getNewTestConfig();
   shopify = shopifyApi(testConfig);
+});
+
+test('passes test deprecation checks', () => {
+  expect('9999.0.0').toBeWithinDeprecationSchedule();
+  expect(() => expect('1.0.0').toBeWithinDeprecationSchedule()).toThrow();
+  expect(() =>
+    expect(SHOPIFY_API_LIBRARY_VERSION).toBeWithinDeprecationSchedule(),
+  ).toThrow();
 });
 
 export {shopify, testConfig};

--- a/lib/error.ts
+++ b/lib/error.ts
@@ -115,3 +115,5 @@ export class BillingError extends ShopifyError {
     this.errorData = errorData;
   }
 }
+
+export class FeatureDeprecatedError extends ShopifyError {}

--- a/lib/logger/__tests__/logger.test.ts
+++ b/lib/logger/__tests__/logger.test.ts
@@ -1,4 +1,6 @@
+import {FeatureDeprecatedError} from '../../error';
 import {LogSeverity} from '../../types';
+import {SHOPIFY_API_LIBRARY_VERSION} from '../../version';
 import {shopify} from '../../__tests__/test-helper';
 
 describe('shopify.logger', () => {
@@ -79,6 +81,24 @@ describe('shopify.logger', () => {
         LogSeverity.Error,
         expect.stringContaining('error message'),
       );
+    });
+
+    it('can log deprecations for future versions', async () => {
+      await shopify.logger.deprecated('9999.0.0', 'This is a test');
+
+      expect(shopify.config.logger.log).toHaveBeenCalledWith(
+        LogSeverity.Warning,
+        expect.stringContaining('[Deprecated | 9999.0.0]'),
+      );
+    });
+
+    it('throws an error when we move past the release version', async () => {
+      await expect(
+        shopify.logger.deprecated(
+          SHOPIFY_API_LIBRARY_VERSION,
+          'This is a test',
+        ),
+      ).rejects.toThrow(FeatureDeprecatedError);
     });
   });
 

--- a/lib/logger/index.ts
+++ b/lib/logger/index.ts
@@ -1,7 +1,11 @@
+import semver from 'semver';
+
 import {LogSeverity} from '../types';
 import {ConfigInterface} from '../base-types';
+import {FeatureDeprecatedError} from '../error';
+import {SHOPIFY_API_LIBRARY_VERSION} from '../version';
 
-import {log} from './log';
+import {log, LoggerFunction} from './log';
 import {LogContext} from './types';
 
 export function logger(config: ConfigInterface) {
@@ -17,7 +21,23 @@ export function logger(config: ConfigInterface) {
       logFunction(LogSeverity.Warning, message, context),
     error: async (message: string, context: LogContext = {}) =>
       logFunction(LogSeverity.Error, message, context),
+    deprecated: deprecated(logFunction),
   };
 }
 
 export type ShopifyLogger = ReturnType<typeof logger>;
+
+function deprecated(logFunction: LoggerFunction) {
+  return async function (version: string, message: string): Promise<void> {
+    if (semver.gte(SHOPIFY_API_LIBRARY_VERSION, version)) {
+      throw new FeatureDeprecatedError(
+        `Feature was deprecated in version ${version}`,
+      );
+    }
+
+    return logFunction(
+      LogSeverity.Warning,
+      `[Deprecated | ${version}] ${message}`,
+    );
+  };
+}

--- a/lib/setup-jest.ts
+++ b/lib/setup-jest.ts
@@ -1,6 +1,10 @@
+import semver from 'semver';
+
 import '../adapters/mock';
 import {mockTestRequests} from '../adapters/mock/mock_test_requests';
 import {canonicalizeHeaders} from '../runtime/http';
+
+import {SHOPIFY_API_LIBRARY_VERSION} from './version';
 
 beforeEach(() => {
   mockTestRequests.reset();
@@ -121,6 +125,13 @@ expect.extend({
     return {
       message: () => `expected to have seen the right HTTP requests`,
       pass: true,
+    };
+  },
+  toBeWithinDeprecationSchedule(version: string) {
+    return {
+      message: () =>
+        `Found deprecation limited to version ${version}, please update or remove it.`,
+      pass: semver.lt(SHOPIFY_API_LIBRARY_VERSION, version),
     };
   },
 });


### PR DESCRIPTION
### WHY are these changes introduced?

In order to make it easier for developers to spot upcoming breaking changes, we're introducing a new `deprecate` method that will trigger a warning-level log.

### WHAT is this pull request doing?

Adding that method, and adding a check to make this method break once we reach a certain version of the library, to prevent us from going over the desired release version that fully removes the deprecated code without actually doing it.

The check only applies if `process.env.CI` is true.

## Checklist

- [x] I have added/updated tests for this change
