### PR TITLE
Usage Based Billing Helper functions

### DIFF
--- a/docs/usage/billing.md
+++ b/docs/usage/billing.md
@@ -41,13 +41,33 @@ const shopify = shopifyApi({
 
 This setting is a collection of billing plans. Each billing plan allows the following properties:
 
+### One Time Billing Plans
 | Parameter             | Type                         | Required? | Default Value | Notes                                                                                                                                                                                            |
 | --------------------- | ---------------------------- | :-------: | :-----------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `amount`              | `number`                     |    Yes    |       -       | The amount to charge                                                                                                                                                                             |
 | `currencyCode`        | `string`                     |    Yes    |       -       | The currency to charge, currently only `"USD"` is accepted                                                                                                                                       |
-| `interval`            | `BillingInterval`            |    Yes    |       -       | `BillingInterval` value                                                                                                                                                                          |
-| `trialDays`           | `number`                     |    No     |       -       | Give merchants this many days before charging. _Not available for `OneTime` plans_                                                                                                               |
-| `replacementBehavior` | `BillingReplacementBehavior` |    No     |       -       | `BillingReplacementBehavior` value, see [the reference](https://shopify.dev/api/admin-graphql/2022-07/mutations/appSubscriptionCreate) for more information. _Not available for `OneTime` plans_ |
+| `interval`            | `ONE_TIME`            |    Yes    |       -       | `BillingInterval.OneTime` value                                                                                                                                                     
+
+### Recurring Billing Plans
+| Parameter             | Type                         | Required? | Default Value | Notes                                                                                                                                                                                            |
+| --------------------- | ---------------------------- | :-------: | :-----------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `amount`              | `number`                     |    Yes    |       -       | The amount to charge                                                                                                                                                                             |
+| `currencyCode`        | `string`                     |    Yes    |       -       | The currency to charge, currently only `"USD"` is accepted                                                                                                                                       |
+| `interval`            | `EVERY_30_DAYS`, `ANNUAL`            |    Yes    |       -       | `BillingInterval.Every30Days`, `BillingInterval.Annual` value                                                                                                                                                                          |
+| `trialDays`           | `number`                     |    No     |       -       | Give merchants this many days before charging                                                                                                              |
+| `replacementBehavior` | `BillingReplacementBehavior` |    No     |       -       | `BillingReplacementBehavior` value, see [the reference](https://shopify.dev/api/admin-graphql/2022-07/mutations/appSubscriptionCreate) for more information. |
+
+### Usage Billing Plans
+
+| Parameter             | Type                         | Required? | Default Value | Notes                                                                                                                                                                                            |
+| --------------------- | ---------------------------- | :-------: | :-----------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `amount`              | `number`                     |    Yes    |       -       | The maximum amount the merchant will be charged                                                                                                                                                                            |
+| `currencyCode` | `string`      |    Yes    |       -       | The currency to charge, currently only `"USD"` is accepted                                                                                                                                       |
+| `interval`            | `USAGE`            |    Yes    |       -       | `BillingInterval.Usage`                                                                                                                                                                          |
+| `usageTerms`              | `string`                     |    Yes    |       -       | These terms stipulate the pricing model for the charges that an app creates.  |
+ `trialDays`           | `number`                     |    No     |       -       | Give merchants this many days before charging                                                                                                              |
+ | `replacementBehavior` | `BillingReplacementBehavior` |    No     |       -       | `BillingReplacementBehavior` value, see [the reference](https://shopify.dev/api/admin-graphql/2022-07/mutations/appSubscriptionCreate) for more information. |
+
 
 ## Checking for payment
 

--- a/lib/billing/__tests__/request_payment.test.ts
+++ b/lib/billing/__tests__/request_payment.test.ts
@@ -30,6 +30,65 @@ interface TestConfigInterface {
   mutationName: string;
 }
 
+const TEST_CONFIGS: TestConfigInterface[] = [
+  {
+    name: 'non-recurring config',
+    billingConfig: {
+      [Responses.PLAN_1]: {
+        amount: 5,
+        currencyCode: 'USD',
+        interval: BillingInterval.OneTime,
+      },
+      [Responses.PLAN_2]: {
+        amount: 10,
+        currencyCode: 'USD',
+        interval: BillingInterval.OneTime,
+      },
+    },
+    paymentResponse: Responses.PURCHASE_ONE_TIME_RESPONSE,
+    errorResponse: Responses.PURCHASE_ONE_TIME_RESPONSE_WITH_USER_ERRORS,
+    mutationName: 'appPurchaseOneTimeCreate',
+  },
+  {
+    name: 'recurring config',
+    billingConfig: {
+      [Responses.PLAN_1]: {
+        amount: 5,
+        currencyCode: 'USD',
+        interval: BillingInterval.Every30Days,
+      },
+      [Responses.PLAN_2]: {
+        amount: 10,
+        currencyCode: 'USD',
+        interval: BillingInterval.Annual,
+      },
+    },
+    paymentResponse: Responses.PURCHASE_SUBSCRIPTION_RESPONSE,
+    errorResponse: Responses.PURCHASE_SUBSCRIPTION_RESPONSE_WITH_USER_ERRORS,
+    mutationName: 'appSubscriptionCreate',
+  },
+  {
+    name: 'usage config',
+    billingConfig: {
+      [Responses.PLAN_1]: {
+        amount: 5,
+        currencyCode: 'USD',
+        usageTerms: '1 dollar per click',
+        interval: BillingInterval.Usage,
+      },
+      [Responses.PLAN_2]: {
+        amount: 10,
+        currencyCode: 'USD',
+        usageTerms: '1 dollar per email',
+        interval: BillingInterval.Usage,
+      },
+    },
+    paymentResponse: Responses.PURCHASE_SUBSCRIPTION_RESPONSE,
+    errorResponse: Responses.PURCHASE_SUBSCRIPTION_RESPONSE_WITH_USER_ERRORS,
+    mutationName: 'appSubscriptionCreate',
+  },
+];
+
 describe('shopify.billing.request', () => {
   const session = new Session({
     id: '1234',
@@ -58,45 +117,6 @@ describe('shopify.billing.request', () => {
       ).rejects.toThrowError(BillingError);
     });
   });
-
-  const TEST_CONFIGS: TestConfigInterface[] = [
-    {
-      name: 'non-recurring config',
-      billingConfig: {
-        [Responses.PLAN_1]: {
-          amount: 5,
-          currencyCode: 'USD',
-          interval: BillingInterval.OneTime,
-        },
-        [Responses.PLAN_2]: {
-          amount: 10,
-          currencyCode: 'USD',
-          interval: BillingInterval.OneTime,
-        },
-      },
-      paymentResponse: Responses.PURCHASE_ONE_TIME_RESPONSE,
-      errorResponse: Responses.PURCHASE_ONE_TIME_RESPONSE_WITH_USER_ERRORS,
-      mutationName: 'appPurchaseOneTimeCreate',
-    },
-    {
-      name: 'recurring config',
-      billingConfig: {
-        [Responses.PLAN_1]: {
-          amount: 5,
-          currencyCode: 'USD',
-          interval: BillingInterval.Every30Days,
-        },
-        [Responses.PLAN_2]: {
-          amount: 10,
-          currencyCode: 'USD',
-          interval: BillingInterval.Annual,
-        },
-      },
-      paymentResponse: Responses.PURCHASE_SUBSCRIPTION_RESPONSE,
-      errorResponse: Responses.PURCHASE_SUBSCRIPTION_RESPONSE_WITH_USER_ERRORS,
-      mutationName: 'appSubscriptionCreate',
-    },
-  ];
 
   TEST_CONFIGS.forEach((config) => {
     describe(`with ${config.name}`, () => {

--- a/lib/billing/__tests__/request_payment.test.ts
+++ b/lib/billing/__tests__/request_payment.test.ts
@@ -1,7 +1,12 @@
 import {testConfig, queueMockResponses} from '../../__tests__/test-helper';
 import {Session} from '../../session/session';
 import {BillingError} from '../../error';
-import {LATEST_API_VERSION, BillingInterval} from '../../types';
+import {
+  LATEST_API_VERSION,
+  BillingInterval,
+  BillingReplacementBehavior,
+} from '../../types';
+import {BillingConfig} from '../types';
 import {shopifyApi, Shopify} from '../..';
 
 import * as Responses from './responses';
@@ -16,6 +21,14 @@ const GRAPHQL_BASE_REQUEST = {
 };
 
 let shopify: Shopify;
+
+interface TestConfigInterface {
+  name: string;
+  billingConfig: BillingConfig;
+  paymentResponse: string;
+  errorResponse: string;
+  mutationName: string;
+}
 
 describe('shopify.billing.request', () => {
   const session = new Session({
@@ -46,237 +59,179 @@ describe('shopify.billing.request', () => {
     });
   });
 
-  describe('with non-recurring config', () => {
-    beforeEach(() => {
-      shopify = shopifyApi({
-        ...testConfig,
-        billing: {
-          [Responses.PLAN_1]: {
-            amount: 5,
-            currencyCode: 'USD',
-            interval: BillingInterval.OneTime,
-          },
-          [Responses.PLAN_2]: {
-            amount: 10,
-            currencyCode: 'USD',
-            interval: BillingInterval.OneTime,
-          },
+  const TEST_CONFIGS: TestConfigInterface[] = [
+    {
+      name: 'non-recurring config',
+      billingConfig: {
+        [Responses.PLAN_1]: {
+          amount: 5,
+          currencyCode: 'USD',
+          interval: BillingInterval.OneTime,
         },
-      });
-    });
+        [Responses.PLAN_2]: {
+          amount: 10,
+          currencyCode: 'USD',
+          interval: BillingInterval.OneTime,
+        },
+      },
+      paymentResponse: Responses.PURCHASE_ONE_TIME_RESPONSE,
+      errorResponse: Responses.PURCHASE_ONE_TIME_RESPONSE_WITH_USER_ERRORS,
+      mutationName: 'appPurchaseOneTimeCreate',
+    },
+    {
+      name: 'recurring config',
+      billingConfig: {
+        [Responses.PLAN_1]: {
+          amount: 5,
+          currencyCode: 'USD',
+          interval: BillingInterval.Every30Days,
+        },
+        [Responses.PLAN_2]: {
+          amount: 10,
+          currencyCode: 'USD',
+          interval: BillingInterval.Annual,
+        },
+      },
+      paymentResponse: Responses.PURCHASE_SUBSCRIPTION_RESPONSE,
+      errorResponse: Responses.PURCHASE_SUBSCRIPTION_RESPONSE_WITH_USER_ERRORS,
+      mutationName: 'appSubscriptionCreate',
+    },
+  ];
 
-    [true, false].forEach((isTest) =>
-      test(`can request a one-time payment (isTest: ${isTest})`, async () => {
-        queueMockResponses([Responses.PURCHASE_ONE_TIME_RESPONSE]);
+  TEST_CONFIGS.forEach((config) => {
+    describe(`with ${config.name}`, () => {
+      beforeEach(() => {
+        shopify = shopifyApi({
+          ...testConfig,
+          billing: config.billingConfig,
+        });
+      });
+
+      [true, false].forEach((isTest) =>
+        test(`can request payment (isTest: ${isTest})`, async () => {
+          queueMockResponses([config.paymentResponse]);
+
+          const response = await shopify.billing.request({
+            session,
+            plan: Responses.PLAN_1,
+            isTest,
+          });
+
+          expect(response).toBe(Responses.CONFIRMATION_URL);
+          expect({
+            ...GRAPHQL_BASE_REQUEST,
+            data: {
+              query: expect.stringContaining(config.mutationName),
+              variables: expect.objectContaining({test: isTest}),
+            },
+          }).toMatchMadeHttpRequest();
+        }),
+      );
+
+      test('defaults to test purchases', async () => {
+        queueMockResponses([config.paymentResponse]);
 
         const response = await shopify.billing.request({
           session,
           plan: Responses.PLAN_1,
-          isTest,
         });
 
         expect(response).toBe(Responses.CONFIRMATION_URL);
         expect({
           ...GRAPHQL_BASE_REQUEST,
           data: {
-            query: expect.stringContaining('appPurchaseOneTimeCreate'),
-            variables: expect.objectContaining({test: isTest}),
+            query: expect.stringContaining(config.mutationName),
+            variables: expect.objectContaining({test: true}),
           },
         }).toMatchMadeHttpRequest();
-      }),
-    );
-
-    test('defaults to test purchases', async () => {
-      queueMockResponses([Responses.PURCHASE_ONE_TIME_RESPONSE]);
-
-      const response = await shopify.billing.request({
-        session,
-        plan: Responses.PLAN_1,
       });
 
-      expect(response).toBe(Responses.CONFIRMATION_URL);
-      expect({
-        ...GRAPHQL_BASE_REQUEST,
-        data: {
-          query: expect.stringContaining('appPurchaseOneTimeCreate'),
-          variables: expect.objectContaining({test: true}),
-        },
-      }).toMatchMadeHttpRequest();
-    });
+      test('can request multiple plans', async () => {
+        queueMockResponses([config.paymentResponse], [config.paymentResponse]);
 
-    test('can request multiple plans', async () => {
-      queueMockResponses(
-        [Responses.PURCHASE_ONE_TIME_RESPONSE],
-        [Responses.PURCHASE_ONE_TIME_RESPONSE],
-      );
-
-      const response1 = await shopify.billing.request({
-        session,
-        plan: Responses.PLAN_1,
-      });
-
-      expect(response1).toBe(Responses.CONFIRMATION_URL);
-      expect({
-        ...GRAPHQL_BASE_REQUEST,
-        data: {
-          query: expect.stringContaining('appPurchaseOneTimeCreate'),
-          variables: expect.objectContaining({
-            name: Responses.PLAN_1,
-          }),
-        },
-      }).toMatchMadeHttpRequest();
-
-      const response2 = await shopify.billing.request({
-        session,
-        plan: Responses.PLAN_2,
-      });
-
-      expect(response2).toBe(Responses.CONFIRMATION_URL);
-      expect({
-        ...GRAPHQL_BASE_REQUEST,
-        data: {
-          query: expect.stringContaining('appPurchaseOneTimeCreate'),
-          variables: expect.objectContaining({
-            name: Responses.PLAN_2,
-          }),
-        },
-      }).toMatchMadeHttpRequest();
-    });
-
-    test('throws on userErrors', async () => {
-      queueMockResponses([
-        Responses.PURCHASE_ONE_TIME_RESPONSE_WITH_USER_ERRORS,
-      ]);
-
-      await expect(() =>
-        shopify.billing.request({
+        const response1 = await shopify.billing.request({
           session,
           plan: Responses.PLAN_1,
-          isTest: true,
-        }),
-      ).rejects.toThrow(BillingError);
+        });
 
-      expect({
-        ...GRAPHQL_BASE_REQUEST,
-        data: expect.stringContaining('appPurchaseOneTimeCreate'),
-      }).toMatchMadeHttpRequest();
+        expect(response1).toBe(Responses.CONFIRMATION_URL);
+        expect({
+          ...GRAPHQL_BASE_REQUEST,
+          data: {
+            query: expect.stringContaining(config.mutationName),
+            variables: expect.objectContaining({
+              name: Responses.PLAN_1,
+            }),
+          },
+        }).toMatchMadeHttpRequest();
+
+        const response2 = await shopify.billing.request({
+          session,
+          plan: Responses.PLAN_2,
+        });
+
+        expect(response2).toBe(Responses.CONFIRMATION_URL);
+        expect({
+          ...GRAPHQL_BASE_REQUEST,
+          data: {
+            query: expect.stringContaining(config.mutationName),
+            variables: expect.objectContaining({
+              name: Responses.PLAN_2,
+            }),
+          },
+        }).toMatchMadeHttpRequest();
+      });
+
+      test('throws on userErrors', async () => {
+        queueMockResponses([config.errorResponse]);
+
+        await expect(() =>
+          shopify.billing.request({
+            session,
+            plan: Responses.PLAN_1,
+            isTest: true,
+          }),
+        ).rejects.toThrow(BillingError);
+
+        expect({
+          ...GRAPHQL_BASE_REQUEST,
+          data: expect.stringContaining(config.mutationName),
+        }).toMatchMadeHttpRequest();
+      });
     });
   });
 
-  describe('with recurring config', () => {
-    beforeEach(() => {
-      shopify = shopifyApi({
-        ...testConfig,
-        billing: {
-          [Responses.PLAN_1]: {
-            amount: 5,
-            currencyCode: 'USD',
-            interval: BillingInterval.Every30Days,
-          },
-          [Responses.PLAN_2]: {
-            amount: 10,
-            currencyCode: 'USD',
-            interval: BillingInterval.Annual,
-          },
+  test('can request subscription with extra fields', async () => {
+    shopify = shopifyApi({
+      ...testConfig,
+      billing: {
+        [Responses.PLAN_1]: {
+          amount: 5,
+          currencyCode: 'USD',
+          interval: BillingInterval.Every30Days,
+          replacementBehavior: BillingReplacementBehavior.ApplyImmediately,
+          trialDays: 10,
         },
-      });
+      },
     });
 
-    [true, false].forEach((isTest) =>
-      test(`can request a subscription (isTest: ${isTest})`, async () => {
-        queueMockResponses([Responses.PURCHASE_SUBSCRIPTION_RESPONSE]);
+    queueMockResponses([Responses.PURCHASE_SUBSCRIPTION_RESPONSE]);
 
-        const response = await shopify.billing.request({
-          session,
-          plan: Responses.PLAN_1,
-          isTest,
-        });
-
-        expect(response).toBe(Responses.CONFIRMATION_URL);
-        expect({
-          ...GRAPHQL_BASE_REQUEST,
-          data: {
-            query: expect.stringContaining('appSubscriptionCreate'),
-            variables: expect.objectContaining({test: isTest}),
-          },
-        }).toMatchMadeHttpRequest();
-      }),
-    );
-
-    test('defaults to test purchases', async () => {
-      queueMockResponses([Responses.PURCHASE_SUBSCRIPTION_RESPONSE]);
-
-      const response = await shopify.billing.request({
-        session,
-        plan: Responses.PLAN_1,
-      });
-
-      expect(response).toBe(Responses.CONFIRMATION_URL);
-      expect({
-        ...GRAPHQL_BASE_REQUEST,
-        data: {
-          query: expect.stringContaining('appSubscriptionCreate'),
-          variables: expect.objectContaining({test: true}),
-        },
-      }).toMatchMadeHttpRequest();
+    const response = await shopify.billing.request({
+      session,
+      plan: Responses.PLAN_1,
     });
 
-    test('throws on userErrors', async () => {
-      queueMockResponses([
-        Responses.PURCHASE_SUBSCRIPTION_RESPONSE_WITH_USER_ERRORS,
-      ]);
-
-      await expect(() =>
-        shopify.billing.request({
-          session,
-          plan: Responses.PLAN_1,
-          isTest: true,
+    expect(response).toBe(Responses.CONFIRMATION_URL);
+    expect({
+      ...GRAPHQL_BASE_REQUEST,
+      data: {
+        query: expect.stringContaining('appSubscriptionCreate'),
+        variables: expect.objectContaining({
+          trialDays: 10,
+          replacementBehavior: BillingReplacementBehavior.ApplyImmediately,
         }),
-      ).rejects.toThrow(BillingError);
-
-      expect({
-        ...GRAPHQL_BASE_REQUEST,
-        data: expect.stringContaining('appSubscriptionCreate'),
-      }).toMatchMadeHttpRequest();
-    });
-
-    test('can request multiple plans', async () => {
-      queueMockResponses(
-        [Responses.PURCHASE_SUBSCRIPTION_RESPONSE],
-        [Responses.PURCHASE_SUBSCRIPTION_RESPONSE],
-      );
-
-      const response1 = await shopify.billing.request({
-        session,
-        plan: Responses.PLAN_1,
-      });
-
-      expect(response1).toBe(Responses.CONFIRMATION_URL);
-      expect({
-        ...GRAPHQL_BASE_REQUEST,
-        data: {
-          query: expect.stringContaining('appSubscriptionCreate'),
-          variables: expect.objectContaining({
-            name: Responses.PLAN_1,
-          }),
-        },
-      }).toMatchMadeHttpRequest();
-
-      const response2 = await shopify.billing.request({
-        session,
-        plan: Responses.PLAN_2,
-      });
-
-      expect(response2).toBe(Responses.CONFIRMATION_URL);
-      expect({
-        ...GRAPHQL_BASE_REQUEST,
-        data: {
-          query: expect.stringContaining('appSubscriptionCreate'),
-          variables: expect.objectContaining({
-            name: Responses.PLAN_2,
-          }),
-        },
-      }).toMatchMadeHttpRequest();
-    });
+      },
+    }).toMatchMadeHttpRequest();
   });
 });

--- a/lib/billing/request.ts
+++ b/lib/billing/request.ts
@@ -61,35 +61,40 @@ export function createRequest(config: ConfigInterface) {
     const client = new GraphqlClient({session});
 
     let data: RequestResponse;
-    if (billingConfig.interval === BillingInterval.OneTime) {
-      const mutationResponse = await requestSinglePayment({
-        billingConfig: billingConfig as BillingConfigOneTimePlan,
-        plan,
-        client,
-        returnUrl,
-        isTest,
-      });
-      data = mutationResponse.data.appPurchaseOneTimeCreate;
-    } else if (billingConfig.interval === BillingInterval.Usage) {
-      const mutationResponse = await requestUsagePayment({
-        billingConfig: billingConfig as BillingConfigUsagePlan,
-        plan,
-        client,
-        returnUrl,
-        isTest,
-      });
-      data = mutationResponse.data.appSubscriptionCreate;
-    } else {
-      const mutationResponse = await requestRecurringPayment({
-        billingConfig: billingConfig as BillingConfigSubscriptionPlan,
-        plan,
-        client,
-        returnUrl,
-        isTest,
-      });
-      data = mutationResponse.data.appSubscriptionCreate;
+    switch (billingConfig.interval) {
+      case BillingInterval.OneTime: {
+        const mutationOneTimeResponse = await requestSinglePayment({
+          billingConfig: billingConfig as BillingConfigOneTimePlan,
+          plan,
+          client,
+          returnUrl,
+          isTest,
+        });
+        data = mutationOneTimeResponse.data.appPurchaseOneTimeCreate;
+        break;
+      }
+      case BillingInterval.Usage: {
+        const mutationUsageResponse = await requestUsagePayment({
+          billingConfig: billingConfig as BillingConfigUsagePlan,
+          plan,
+          client,
+          returnUrl,
+          isTest,
+        });
+        data = mutationUsageResponse.data.appSubscriptionCreate;
+        break;
+      }
+      default: {
+        const mutationRecurringResponse = await requestRecurringPayment({
+          billingConfig: billingConfig as BillingConfigSubscriptionPlan,
+          plan,
+          client,
+          returnUrl,
+          isTest,
+        });
+        data = mutationRecurringResponse.data.appSubscriptionCreate;
+      }
     }
-
     if (data.userErrors?.length) {
       throw new BillingError({
         message: 'Error while billing the store',

--- a/lib/billing/types.ts
+++ b/lib/billing/types.ts
@@ -23,6 +23,8 @@ export interface BillingConfigSubscriptionPlan extends BillingConfigPlan {
 export interface BillingConfigUsagePlan extends BillingConfigPlan {
   interval: BillingInterval.Usage;
   usageTerms: string;
+  trialDays?: number;
+  replacementBehavior?: BillingReplacementBehavior;
 }
 
 export interface BillingConfig {

--- a/lib/billing/types.ts
+++ b/lib/billing/types.ts
@@ -20,8 +20,16 @@ export interface BillingConfigSubscriptionPlan extends BillingConfigPlan {
   replacementBehavior?: BillingReplacementBehavior;
 }
 
+export interface BillingConfigUsagePlan extends BillingConfigPlan {
+  interval: BillingInterval.Usage;
+  usageTerms: string;
+}
+
 export interface BillingConfig {
-  [plan: string]: BillingConfigOneTimePlan | BillingConfigSubscriptionPlan;
+  [plan: string]:
+    | BillingConfigOneTimePlan
+    | BillingConfigSubscriptionPlan
+    | BillingConfigUsagePlan;
 }
 
 export interface CheckParams {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -38,6 +38,7 @@ export enum BillingInterval {
   OneTime = 'ONE_TIME',
   Every30Days = 'EVERY_30_DAYS',
   Annual = 'ANNUAL',
+  Usage = 'USAGE',
 }
 
 export type RecurringBillingIntervals = Exclude<


### PR DESCRIPTION
### WHAT is this pull request doing?

* Adding helper functions for Usage Based Billing
* Users can specify usage based billing in their App Config

```javascript
//shopify.js

const shopify = shopifyApp({
  api: {
    restResources,
    billing: {
      "Usage Billing API Plan": {
        amount: 5,
        currencyCode: 'USD',
        interval: BillingInterval.Usage,
        usageTerms: '1 dollar per click',
      }
    }
  },
  // This should be replaced with your preferred storage strategy
  sessionStorage: new SQLiteSessionStorage(DB_PATH),
});
```


## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)

https://user-images.githubusercontent.com/23265671/205750401-6e41c7e0-e053-4d11-94a0-dc4079ec7b65.mp4


